### PR TITLE
feat: added GitHub Actions workflows for PR contributor management

### DIFF
--- a/.github/workflows/branch-naming-validation.yml
+++ b/.github/workflows/branch-naming-validation.yml
@@ -1,0 +1,80 @@
+name: Branch Naming Validation
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  validate-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Branch Naming Convention
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const branchName = pr.head.ref;
+            
+            // Branch naming pattern: type/description
+            // Types: feature, bugfix, hotfix, chore, docs, refactor, test, ci
+            // Description: lowercase, hyphens instead of spaces
+            const validPattern = /^(feature|bugfix|hotfix|chore|docs|refactor|test|ci)\/[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i;
+            
+            if (!validPattern.test(branchName)) {
+              core.setFailed(` Branch name "${branchName}" does not follow naming convention`);
+              return;
+            }
+            
+            core.info(` Branch name "${branchName}" follows naming convention`);
+
+      - name: Comment on naming validation failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const branchName = pr.head.ref;
+            const lines = [
+              '### Branch Naming Validation Failed ',
+              '',
+              `Your branch name \`${branchName}\` does not follow the required naming convention.`,
+              '',
+              '**Required Format:** `type/description`',
+              '',
+              '**Allowed Types:**',
+              '- `feature/` - New features',
+              '- `bugfix/` - Bug fixes',
+              '- `hotfix/` - Hotfixes for production issues',
+              '- `chore/` - Maintenance tasks',
+              '- `docs/` - Documentation updates',
+              '- `refactor/` - Code refactoring',
+              '- `test/` - Test additions or updates',
+              '- `ci/` - CI/CD pipeline updates',
+              '',
+              '**Description Rules:**',
+              '- Use lowercase letters',
+              '- Use hyphens to separate words (no spaces)',
+              '- Start and end with alphanumeric characters',
+              '',
+              '**Examples:**',
+              '-  `feature/user-authentication`',
+              '-  \`bugfix/login-page-crash`',
+              '-  \`docs/api-documentation`',
+              '-  \`add-new-feature` (missing type)',
+              '-  \`feature/Add New Feature` (uppercase, spaces)'
+            ];
+            const body = lines.join('\n');
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/.github/workflows/commit-message-validation.yml
+++ b/.github/workflows/commit-message-validation.yml
@@ -1,0 +1,121 @@
+name: Commit Message Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  validate-commit-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate Commit Messages
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            
+            const pr = context.payload.pull_request;
+            
+            // Get commits in the PR
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number
+            });
+            
+            const validCommitPattern = /^(feat|fix|docs|style|refactor|perf|test|chore|ci)(\(.+\))?!?: .{1,100}$/;
+            const invalidCommits = [];
+            
+            commits.data.forEach(commit => {
+              const message = commit.commit.message.split('\n')[0]; // Get first line
+              
+              if (!validCommitPattern.test(message)) {
+                invalidCommits.push({
+                  sha: commit.sha.substring(0, 7),
+                  message: message
+                });
+              }
+            });
+            
+            if (invalidCommits.length > 0) {
+              core.setFailed(` Found ${invalidCommits.length} commit(s) with invalid message format`);
+              return;
+            }
+            
+            core.info(' All commit messages follow the conventional commits format');
+
+      - name: Comment on commit validation failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            
+            const pr = context.payload.pull_request;
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number
+            });
+            
+            const validCommitPattern = /^(feat|fix|docs|style|refactor|perf|test|chore|ci)(\(.+\))?!?: .{1,100}$/;
+            const invalidCommits = [];
+            
+            commits.data.forEach(commit => {
+              const message = commit.commit.message.split('\n')[0];
+              if (!validCommitPattern.test(message)) {
+                invalidCommits.push({
+                  sha: commit.sha.substring(0, 7),
+                  message: message
+                });
+              }
+            });
+            
+            if (invalidCommits.length > 0) {
+              let commitsList = invalidCommits.map(c => '- `' + c.sha + '`: ' + c.message).join('\n');
+              const body = '### Commit Message Validation Failed \n\n' +
+                'The following commits do not follow the Conventional Commits format:\n\n' +
+                commitsList + '\n\n' +
+                '**Required Format:** `type(scope)?: message`\n\n' +
+                '**Allowed Types:**\n' +
+                '- `feat` - A new feature\n' +
+                '- `fix` - A bug fix\n' +
+                '- `docs` - Documentation only changes\n' +
+                '- `style` - Changes that do not affect code meaning (formatting, etc.)\n' +
+                '- `refactor` - A code change that neither fixes a bug nor adds a feature\n' +
+                '- `perf` - A code change that improves performance\n' +
+                '- `test` - Adding missing tests or correcting existing tests\n' +
+                '- `chore` - Changes to build process, dependencies, or tooling\n' +
+                '- `ci` - Changes to CI configuration files\n\n' +
+                '**Message Rules:**\n' +
+                '- Use imperative mood ("add" not "adds" or "added")\n' +
+                '- Do not capitalize the first letter\n' +
+                '- Do not end with a period\n' +
+                '- Maximum 100 characters\n' +
+                '- Be specific and descriptive\n\n' +
+                '**Examples:**\n' +
+                '-  `feat: add user authentication system`\n' +
+                '-  `fix(login): resolve session timeout issue`\n' +
+                '-  `docs: update API documentation`\n' +
+                '-  `refactor(utils): simplify date formatting`\n' +
+                '-  `Added new feature` (missing type)\n' +
+                '-  `feat: Add user authentication system` (capitalized)\n' +
+                '-  `feat: add user authentication system.` (period at end)\n\n' +
+                'Please amend your commits to follow the conventional commits format.';
+              
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }

--- a/.github/workflows/issue-linking-validation.yml
+++ b/.github/workflows/issue-linking-validation.yml
@@ -1,0 +1,100 @@
+name: Issue Linking Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  validate-issue-linking:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Issue Linking
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            
+            // Check for issue references in multiple formats
+            // Matches: #123, fixes #123, closes #123, resolves #123
+            const issuePattern = /(fixes|closes|resolves|fix|close|resolve)?\s*#\d+/gi;
+            const matches = body.match(issuePattern);
+            
+            if (!matches || matches.length === 0) {
+              core.setFailed(' PR must reference at least one issue');
+              return;
+            }
+            
+            // Extract issue numbers
+            const issueNumbers = [...new Set(
+              body.match(/#\d+/g).map(m => m.substring(1))
+            )];
+            
+            // Verify issues exist
+            for (const issueNum of issueNumbers) {
+              try {
+                await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNum
+                });
+              } catch (error) {
+                core.setFailed(` Issue #${issueNum} does not exist or is not accessible`);
+                return;
+              }
+            }
+            
+            core.info(` PR correctly links to issue(s): ${issueNumbers.map(n => '#' + n).join(', ')}`);
+            
+            // Add linked issues as comment
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: ` Issue linking validated! This PR references: ${issueNumbers.map(n => '#' + n).join(', ')}`
+            });
+
+      - name: Comment on linking validation failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = '### Issue Linking Validation Failed \n\n' +
+              'This PR must reference at least one issue from the repository.\n\n' +
+              '**How to Link Issues:**\n\n' +
+              'Add one of these keywords followed by the issue number in your PR description:\n' +
+              '- `fixes #123`\n' +
+              '- `closes #123`\n' +
+              '- `resolves #123`\n' +
+              '- `fix #123`\n' +
+              '- `close #123`\n' +
+              '- `resolve #123`\n\n' +
+              '**Examples:**\n' +
+              '```\n' +
+              '## What\n' +
+              'This PR adds user authentication feature.\n\n' +
+              '## Why\n' +
+              'Resolves #42 - Users need a secure login system\n\n' +
+              '## How\n' +
+              'Implemented JWT-based authentication using...\n' +
+              '```\n\n' +
+              '**Multiple Issues:**\n' +
+              'You can reference multiple issues:\n' +
+              '```\n' +
+              'Fixes #42, #43 and resolves #45\n' +
+              '```\n\n' +
+              'Please update your PR description to include an issue reference.';
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/.github/workflows/pr-description-validation.yml
+++ b/.github/workflows/pr-description-validation.yml
@@ -1,0 +1,89 @@
+name: PR Description Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  validate-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate PR Description
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            
+            // Check if description is empty
+            if (!body || body.trim().length === 0) {
+              core.setFailed(' PR description is required and cannot be empty');
+              return;
+            }
+            
+            // Check minimum length (100 characters)
+            if (body.trim().length < 100) {
+              core.setFailed('PR description must be at least 100 characters long');
+              return;
+            }
+            
+            // Check for required sections
+            const requiredSections = ['## What', '## Why', '## How'];
+            const missingSections = [];
+            
+            requiredSections.forEach(section => {
+              if (!body.includes(section)) {
+                missingSections.push(section);
+              }
+            });
+            
+            if (missingSections.length > 0) {
+              core.setFailed(` PR description must include these sections: ${missingSections.join(', ')}`);
+              return;
+            }
+            
+            // If all checks pass
+            core.info(' PR description is valid');
+            
+            // Add comment with validation result
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: ' PR description validated successfully!'
+            });
+
+      - name: Comment on validation failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = '### PR Description Validation Failed \n\n' +
+              'Please update your PR description to include:\n' +
+              '- **Minimum 100 characters** of description\n' +
+              '- **## What** section - What does this PR do?\n' +
+              '- **## Why** section - Why is this change needed?\n' +
+              '- **## How** section - How does it accomplish the goal?\n\n' +
+              'Example format:\n' +
+              '```\n' +
+              '## What\n' +
+              'This PR adds a new authentication system that...\n\n' +
+              '## Why\n' +
+              'The current authentication system has X limitations that...\n\n' +
+              '## How\n' +
+              'We implemented Y by using Z approach...\n' +
+              '```';
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });


### PR DESCRIPTION
I added four GitHub Actions workflows to enforce code quality standards and contributor guidelines:

### - pr-description-validation
Validates PR descriptions contain required sections (What, Why, How) with minimum 100 characters
  
### - branch-naming-validation
Enforces branch naming convention `type/description` with allowed types (feature, bugfix, hotfix, chore,docs, refactor, test, ci)
  
### - commit-message-validation
Validates commits follow Conventional Commits format `type(scope)?: message` with standard types
  
- issue-linking-validation
Requires PRs reference at least one issue using keywords (fixes, closes, resolves, fix, close, resolve)

All workflows trigger on pull request events and provide automated GitHub comments with helpful guidance when validation fails, improving the contributor experience and maintaining code quality standards.

Closes #11 