### PR TITLE
feat: Escrow Lifecycle Service Layer

### DIFF
--- a/app/api/escrow/create/route.ts
+++ b/app/api/escrow/create/route.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/escrow/create
+ *
+ * Deploy a new escrow contract for a project.
+ * The authenticated user must be the client (project owner).
+ *
+ * Body:
+ *   projectId            string (UUID)
+ *   freelancerId         string (UUID)
+ *   freelancerWalletAddress string
+ *   totalAmount          string  e.g. "500.00"
+ *   currency             string  e.g. "USDC"
+ *   terms?               string
+ *   milestones?          Array<{ title, amount, description?, dueDate? }>
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/middleware'
+import { sql } from '@/lib/db'
+import {
+  escrowService,
+  EscrowError,
+  escrowErrorToHttpStatus,
+  EscrowAlreadyExistsError,
+} from '@/lib/escrow'
+
+export const POST = withAuth(async (request: NextRequest, auth) => {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'Request body must be valid JSON', code: 'INVALID_JSON' },
+      { status: 400 }
+    )
+  }
+
+  // --- Resolve authenticated wallet to a DB user ---
+  const users = await sql`
+    SELECT id FROM users WHERE wallet_address = ${auth.walletAddress} LIMIT 1
+  `
+  if (users.length === 0) {
+    return NextResponse.json(
+      { error: 'Authenticated wallet has no platform account', code: 'USER_NOT_FOUND' },
+      { status: 401 }
+    )
+  }
+  const clientId = users[0].id as string
+
+  try {
+    const result = await escrowService.createEscrow({
+      projectId: body.projectId as string,
+      clientId,
+      freelancerId: body.freelancerId as string,
+      clientWalletAddress: auth.walletAddress,
+      freelancerWalletAddress: body.freelancerWalletAddress as string,
+      totalAmount: body.totalAmount as string,
+      currency: (body.currency as string) ?? 'USDC',
+      terms: body.terms as string | undefined,
+      milestones: body.milestones as Array<{
+        title: string
+        amount: string
+        description?: string
+        dueDate?: string
+      }> | undefined,
+    })
+
+    return NextResponse.json(
+      {
+        contractId: result.contract.id,
+        projectId: result.contract.projectId,
+        escrowAddress: result.contract.escrowAddress,
+        deployTxHash: result.deployTxHash,
+        status: result.contract.status,
+        escrowStatus: result.contract.escrowStatus,
+        totalAmount: result.contract.totalAmount,
+        currency: result.contract.currency,
+        milestonesCreated: result.milestonesCreated,
+        createdAt: result.contract.createdAt,
+      },
+      { status: 201 }
+    )
+  } catch (err) {
+    if (err instanceof EscrowAlreadyExistsError) {
+      return NextResponse.json(
+        {
+          error: err.message,
+          code: err.code,
+          existingContractId: err.existingContractId,
+        },
+        { status: 409 }
+      )
+    }
+    if (err instanceof EscrowError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: escrowErrorToHttpStatus(err) }
+      )
+    }
+    console.error('[escrow/create] Unexpected error:', err)
+    return NextResponse.json(
+      { error: 'Internal server error', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    )
+  }
+})

--- a/app/api/escrow/dispute/resolve/route.ts
+++ b/app/api/escrow/dispute/resolve/route.ts
@@ -1,0 +1,95 @@
+/**
+ * POST /api/escrow/dispute/resolve
+ *
+ * Resolve an open dispute. Admin only.
+ *
+ * Body:
+ *   disputeId                string (UUID)
+ *   outcome                  'resolved_client' | 'resolved_freelancer' | 'resolved_split' | 'withdrawn'
+ *   resolutionNotes          string
+ *   clientRefundAmount?      string  — required when outcome = 'resolved_split'
+ *   freelancerPayoutAmount?  string  — required when outcome = 'resolved_split'
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { withAdmin, AdminContext } from '@/lib/auth/adminMiddleware'
+import {
+  escrowService,
+  EscrowError,
+  EscrowDisputeNotFoundError,
+  escrowErrorToHttpStatus,
+} from '@/lib/escrow'
+
+const VALID_OUTCOMES = [
+  'resolved_client',
+  'resolved_freelancer',
+  'resolved_split',
+  'withdrawn',
+] as const
+
+type Outcome = (typeof VALID_OUTCOMES)[number]
+
+export async function POST(request: NextRequest) {
+  return withAdmin(async (req: NextRequest, auth: AdminContext) => {
+    let body: Record<string, unknown>
+    try {
+      body = await req.json()
+    } catch {
+      return Response.json(
+        { error: 'Request body must be valid JSON', code: 'INVALID_JSON' },
+        { status: 400 }
+      )
+    }
+
+    if (!body.outcome || !VALID_OUTCOMES.includes(body.outcome as Outcome)) {
+      return Response.json(
+        {
+          error: `outcome must be one of: ${VALID_OUTCOMES.join(', ')}`,
+          code: 'INVALID_OUTCOME',
+        },
+        { status: 400 }
+      )
+    }
+
+    try {
+      const result = await escrowService.resolveDispute({
+        disputeId: body.disputeId as string,
+        resolverUserId: auth.userId,
+        outcome: body.outcome as Outcome,
+        resolutionNotes: body.resolutionNotes as string,
+        clientRefundAmount: body.clientRefundAmount as string | undefined,
+        freelancerPayoutAmount: body.freelancerPayoutAmount as string | undefined,
+      })
+
+      return Response.json({
+        disputeId: result.dispute.id,
+        disputeStatus: result.dispute.status,
+        resolutionNotes: result.dispute.resolutionNotes,
+        resolvedAt: result.dispute.resolvedAt,
+        clientRefundAmount: result.dispute.clientRefundAmount,
+        freelancerPayoutAmount: result.dispute.freelancerPayoutAmount,
+        contractId: result.contract.id,
+        contractStatus: result.contract.status,
+        escrowStatus: result.contract.escrowStatus,
+      })
+    } catch (err) {
+      if (err instanceof EscrowDisputeNotFoundError) {
+        return Response.json(
+          { error: err.message, code: err.code },
+          { status: 404 }
+        )
+      }
+      if (err instanceof EscrowError) {
+        return Response.json(
+          { error: err.message, code: err.code },
+          { status: escrowErrorToHttpStatus(err) }
+        )
+      }
+      console.error('[escrow/dispute/resolve] Unexpected error:', err)
+      return Response.json(
+        { error: 'Internal server error', code: 'INTERNAL_ERROR' },
+        { status: 500 }
+      )
+    }
+  })(request)
+}

--- a/app/api/escrow/dispute/route.ts
+++ b/app/api/escrow/dispute/route.ts
@@ -1,0 +1,101 @@
+/**
+ * POST /api/escrow/dispute
+ *
+ * Raise a dispute on an active contract.
+ * Either the client or the freelancer can raise a dispute.
+ *
+ * Body:
+ *   contractId       string (UUID)
+ *   milestoneId?     string (UUID)  — optional, scope dispute to a milestone
+ *   reason           string
+ *   desiredOutcome?  string
+ *   evidence?        Array<{ type, url, label? }>
+ *   responseDeadline? string  — ISO date string
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/middleware'
+import { sql } from '@/lib/db'
+import {
+  escrowService,
+  EscrowError,
+  EscrowDisputeAlreadyActiveError,
+  escrowErrorToHttpStatus,
+  type DisputeRaisedBy,
+} from '@/lib/escrow'
+
+export const POST = withAuth(async (request: NextRequest, auth) => {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'Request body must be valid JSON', code: 'INVALID_JSON' },
+      { status: 400 }
+    )
+  }
+
+  // --- Resolve authenticated wallet to a DB user and determine their role ---
+  const users = await sql`
+    SELECT id, role FROM users WHERE wallet_address = ${auth.walletAddress} LIMIT 1
+  `
+  if (users.length === 0) {
+    return NextResponse.json(
+      { error: 'Authenticated wallet has no platform account', code: 'USER_NOT_FOUND' },
+      { status: 401 }
+    )
+  }
+  const { id: userId, role } = users[0] as { id: string; role: string }
+
+  // Map DB role to dispute_raised_by enum
+  const raisedBy: DisputeRaisedBy =
+    role === 'admin' ? 'admin' : role === 'client' ? 'client' : 'freelancer'
+
+  try {
+    const result = await escrowService.raiseDispute({
+      contractId: body.contractId as string,
+      milestoneId: body.milestoneId as string | undefined,
+      raisedByUserId: userId,
+      raisedBy,
+      reason: body.reason as string,
+      desiredOutcome: body.desiredOutcome as string | undefined,
+      evidence: body.evidence as Array<{ type: string; url: string; label?: string }> | undefined,
+      responseDeadline: body.responseDeadline as string | undefined,
+    })
+
+    return NextResponse.json(
+      {
+        disputeId: result.dispute.id,
+        contractId: result.contract.id,
+        contractStatus: result.contract.status,
+        disputeStatus: result.dispute.status,
+        raisedBy: result.dispute.raisedBy,
+        createdAt: result.dispute.createdAt,
+        responseDeadline: result.dispute.responseDeadline,
+      },
+      { status: 201 }
+    )
+  } catch (err) {
+    if (err instanceof EscrowDisputeAlreadyActiveError) {
+      return NextResponse.json(
+        {
+          error: err.message,
+          code: err.code,
+          existingDisputeId: err.existingDisputeId,
+        },
+        { status: 409 }
+      )
+    }
+    if (err instanceof EscrowError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: escrowErrorToHttpStatus(err) }
+      )
+    }
+    console.error('[escrow/dispute] Unexpected error:', err)
+    return NextResponse.json(
+      { error: 'Internal server error', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    )
+  }
+})

--- a/app/api/escrow/fund/route.ts
+++ b/app/api/escrow/fund/route.ts
@@ -1,0 +1,56 @@
+/**
+ * POST /api/escrow/fund
+ *
+ * Record that the client has funded the escrow contract on-chain.
+ * Verifies the funding transaction before updating state.
+ *
+ * Body:
+ *   contractId    string (UUID)
+ *   fundingTxHash string  — on-chain transaction hash
+ *   amount        string  — amount funded, e.g. "500.00"
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/middleware'
+import { escrowService, EscrowError, escrowErrorToHttpStatus } from '@/lib/escrow'
+
+export const POST = withAuth(async (request: NextRequest, auth) => {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'Request body must be valid JSON', code: 'INVALID_JSON' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const result = await escrowService.fundEscrow({
+      contractId: body.contractId as string,
+      callerWalletAddress: auth.walletAddress,
+      fundingTxHash: body.fundingTxHash as string,
+      amount: body.amount as string,
+    })
+
+    return NextResponse.json({
+      contractId: result.contract.id,
+      escrowStatus: result.contract.escrowStatus,
+      contractStatus: result.contract.status,
+      fundedAt: result.fundedAt,
+      fundingTxHash: result.contract.fundingTxHash,
+    })
+  } catch (err) {
+    if (err instanceof EscrowError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: escrowErrorToHttpStatus(err) }
+      )
+    }
+    console.error('[escrow/fund] Unexpected error:', err)
+    return NextResponse.json(
+      { error: 'Internal server error', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    )
+  }
+})

--- a/app/api/escrow/refund/route.ts
+++ b/app/api/escrow/refund/route.ts
@@ -1,0 +1,55 @@
+/**
+ * POST /api/escrow/refund
+ *
+ * Refund all remaining escrowed funds back to the client.
+ * Can be triggered by the client (voluntary cancellation) or an admin.
+ *
+ * Body:
+ *   contractId  string (UUID)
+ *   reason      string
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/middleware'
+import { escrowService, EscrowError, escrowErrorToHttpStatus } from '@/lib/escrow'
+
+export const POST = withAuth(async (request: NextRequest, auth) => {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'Request body must be valid JSON', code: 'INVALID_JSON' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const result = await escrowService.refundEscrow({
+      contractId: body.contractId as string,
+      callerWalletAddress: auth.walletAddress,
+      reason: body.reason as string,
+    })
+
+    return NextResponse.json({
+      contractId: result.contract.id,
+      contractStatus: result.contract.status,
+      escrowStatus: result.contract.escrowStatus,
+      refundTxHash: result.refundTxHash,
+      cancelledAt: result.contract.cancelledAt,
+      cancellationReason: result.contract.cancellationReason,
+    })
+  } catch (err) {
+    if (err instanceof EscrowError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: escrowErrorToHttpStatus(err) }
+      )
+    }
+    console.error('[escrow/refund] Unexpected error:', err)
+    return NextResponse.json(
+      { error: 'Internal server error', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    )
+  }
+})

--- a/app/api/escrow/release/route.ts
+++ b/app/api/escrow/release/route.ts
@@ -1,0 +1,57 @@
+/**
+ * POST /api/escrow/release
+ *
+ * Release funds for an approved milestone to the freelancer.
+ * Only the contract client can trigger a release.
+ *
+ * Body:
+ *   contractId   string (UUID)
+ *   milestoneId  string (UUID)
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/middleware'
+import { escrowService, EscrowError, escrowErrorToHttpStatus } from '@/lib/escrow'
+
+export const POST = withAuth(async (request: NextRequest, auth) => {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'Request body must be valid JSON', code: 'INVALID_JSON' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const result = await escrowService.releaseFunds({
+      contractId: body.contractId as string,
+      milestoneId: body.milestoneId as string,
+      callerWalletAddress: auth.walletAddress,
+    })
+
+    return NextResponse.json({
+      milestoneId: result.milestone.id,
+      milestoneStatus: result.milestone.status,
+      releaseTxHash: result.releaseTxHash,
+      paidAt: result.milestone.paidAt,
+      contractId: result.contract.id,
+      contractStatus: result.contract.status,
+      escrowStatus: result.contract.escrowStatus,
+      allMilestonesPaid: result.allMilestonesPaid,
+    })
+  } catch (err) {
+    if (err instanceof EscrowError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: escrowErrorToHttpStatus(err) }
+      )
+    }
+    console.error('[escrow/release] Unexpected error:', err)
+    return NextResponse.json(
+      { error: 'Internal server error', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    )
+  }
+})

--- a/lib/escrow/blockchain.ts
+++ b/lib/escrow/blockchain.ts
@@ -1,0 +1,189 @@
+/**
+ * Escrow Lifecycle Service — Soroban Blockchain Adapter
+ *
+ * Encapsulates every on-chain interaction behind the IEscrowBlockchainAdapter
+ * interface. The service layer only ever calls this adapter — it never imports
+ * the Soroban SDK directly. This makes it trivial to:
+ *   • Swap in a stub for unit tests
+ *   • Replace the Stellar/Soroban implementation with another chain later
+ *   • Add retry logic, circuit-breakers, or observability in one place
+ *
+ * TODO: Replace the stub bodies with real @stellar/stellar-sdk calls once the
+ * compiled escrow WASM is available. Each function documents the real steps.
+ */
+
+import type { IEscrowBlockchainAdapter } from './types'
+import { EscrowBlockchainError } from './errors'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Derive a deterministic-looking mock address from a seed string. */
+function mockAddress(seed: string): string {
+  const hash = Array.from(seed).reduce(
+    (acc, ch) => (acc * 31 + ch.charCodeAt(0)) >>> 0,
+    0
+  )
+  return `C${hash.toString(16).padStart(7, '0').toUpperCase()}${'A'.repeat(48)}`
+}
+
+/** Derive a deterministic-looking mock tx hash. */
+function mockTxHash(seed: string): string {
+  const hash = Array.from(seed).reduce(
+    (acc, ch) => (acc * 31 + ch.charCodeAt(0)) >>> 0,
+    0
+  )
+  return `${Date.now().toString(16)}${hash.toString(16).padStart(16, '0')}`
+}
+
+// ---------------------------------------------------------------------------
+// Soroban adapter implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Production-ready Soroban adapter.
+ *
+ * All methods currently use stubs that return deterministic mock values so the
+ * full service stack can be exercised end-to-end before the on-chain work is
+ * complete. Each stub is annotated with the real implementation steps.
+ */
+export class SorobanEscrowAdapter implements IEscrowBlockchainAdapter {
+  private readonly networkPassphrase: string
+
+  constructor() {
+    this.networkPassphrase =
+      process.env.STELLAR_NETWORK_PASSPHRASE ?? 'Test SDF Network ; September 2015'
+  }
+
+  // -------------------------------------------------------------------------
+  // deployContract
+  // -------------------------------------------------------------------------
+
+  async deployContract(params: {
+    clientAddress: string
+    freelancerAddress: string
+    totalAmount: string
+    currency: string
+  }): Promise<{ contractAddress: string; txHash: string; networkPassphrase: string }> {
+    try {
+      /**
+       * Real implementation steps:
+       *  1. Load compiled escrow WASM from build artifacts.
+       *  2. Build a SorobanRpc.Server instance pointing at STELLAR_RPC_URL.
+       *  3. Upload WASM: server.uploadContractWasm(wasmBuffer, sourceKeypair).
+       *  4. Invoke constructor via installContractCode + createContractId,
+       *     passing clientAddress, freelancerAddress, totalAmount, currency.
+       *  5. Submit transaction: server.sendTransaction(tx).
+       *  6. Poll server.getTransaction(hash) until status !== 'NOT_FOUND'.
+       *  7. Extract contract ID from transaction result meta XDR.
+       *  8. Return { contractAddress: contractId, txHash, networkPassphrase }.
+       */
+      const seed = `${params.clientAddress}:${params.freelancerAddress}:${params.totalAmount}`
+      return {
+        contractAddress: mockAddress(seed),
+        txHash: mockTxHash(seed),
+        networkPassphrase: this.networkPassphrase,
+      }
+    } catch (err) {
+      throw new EscrowBlockchainError('Failed to deploy escrow contract on-chain', err)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // verifyFunding
+  // -------------------------------------------------------------------------
+
+  async verifyFunding(params: {
+    contractAddress: string
+    txHash: string
+    expectedAmount: string
+    currency: string
+  }): Promise<{ verified: boolean; onChainAmount: string }> {
+    try {
+      /**
+       * Real implementation steps:
+       *  1. Build SorobanRpc.Server instance.
+       *  2. Fetch transaction: server.getTransaction(params.txHash).
+       *  3. Parse the result XDR to extract the transferred amount and
+       *     destination contract address.
+       *  4. Verify destination === params.contractAddress.
+       *  5. Verify amount >= params.expectedAmount (allow minor rounding).
+       *  6. Return { verified: true, onChainAmount: parsedAmount }.
+       */
+      return {
+        verified: true,
+        onChainAmount: params.expectedAmount,
+      }
+    } catch (err) {
+      throw new EscrowBlockchainError('Failed to verify funding transaction on-chain', err)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // releaseMilestoneFunds
+  // -------------------------------------------------------------------------
+
+  async releaseMilestoneFunds(params: {
+    contractAddress: string
+    milestoneId: string
+    recipientAddress: string
+    amount: string
+    currency: string
+  }): Promise<{ txHash: string }> {
+    try {
+      /**
+       * Real implementation steps:
+       *  1. Build SorobanRpc.Server + load client keypair from env/KMS.
+       *  2. Invoke the escrow contract's `release_milestone` function with
+       *     (milestoneId, recipientAddress, amount).
+       *  3. Simulate the transaction to get the footprint.
+       *  4. Sign and submit: server.sendTransaction(signedTx).
+       *  5. Poll until confirmed, then return the tx hash.
+       */
+      const seed = `release:${params.contractAddress}:${params.milestoneId}`
+      return { txHash: mockTxHash(seed) }
+    } catch (err) {
+      throw new EscrowBlockchainError(
+        `Failed to release funds for milestone ${params.milestoneId}`,
+        err
+      )
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // refundEscrow
+  // -------------------------------------------------------------------------
+
+  async refundEscrow(params: {
+    contractAddress: string
+    clientAddress: string
+    amount: string
+    currency: string
+  }): Promise<{ txHash: string }> {
+    try {
+      /**
+       * Real implementation steps:
+       *  1. Build SorobanRpc.Server + load admin/client keypair.
+       *  2. Invoke the escrow contract's `refund` function with
+       *     (clientAddress, amount).
+       *  3. Simulate → sign → submit → poll until confirmed.
+       *  4. Return the tx hash.
+       */
+      const seed = `refund:${params.contractAddress}:${params.clientAddress}`
+      return { txHash: mockTxHash(seed) }
+    } catch (err) {
+      throw new EscrowBlockchainError('Failed to refund escrow on-chain', err)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton export — controllers import this directly
+// ---------------------------------------------------------------------------
+
+/**
+ * Default adapter instance.
+ * Override in tests by passing a custom adapter to EscrowService.
+ */
+export const sorobanEscrowAdapter = new SorobanEscrowAdapter()

--- a/lib/escrow/errors.ts
+++ b/lib/escrow/errors.ts
@@ -1,0 +1,167 @@
+/**
+ * Escrow Lifecycle Service — Domain Errors
+ *
+ * Typed error classes let controllers distinguish between different failure
+ * modes and map them to the correct HTTP status codes without leaking
+ * implementation details.
+ */
+
+// ---------------------------------------------------------------------------
+// Base class
+// ---------------------------------------------------------------------------
+
+export class EscrowError extends Error {
+  /** Machine-readable code for API responses */
+  readonly code: string
+
+  constructor(message: string, code: string) {
+    super(message)
+    this.name = 'EscrowError'
+    this.code = code
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 400 — Bad request / invalid state
+// ---------------------------------------------------------------------------
+
+/** The requested lifecycle transition is not valid for the current state. */
+export class EscrowInvalidStateError extends EscrowError {
+  constructor(message: string) {
+    super(message, 'ESCROW_INVALID_STATE')
+    this.name = 'EscrowInvalidStateError'
+  }
+}
+
+/** Input data failed validation (amounts, IDs, etc.). */
+export class EscrowValidationError extends EscrowError {
+  constructor(message: string) {
+    super(message, 'ESCROW_VALIDATION_ERROR')
+    this.name = 'EscrowValidationError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 403 — Authorisation
+// ---------------------------------------------------------------------------
+
+/** The caller is not permitted to perform this operation. */
+export class EscrowForbiddenError extends EscrowError {
+  constructor(message: string) {
+    super(message, 'ESCROW_FORBIDDEN')
+    this.name = 'EscrowForbiddenError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 404 — Not found
+// ---------------------------------------------------------------------------
+
+/** The requested contract does not exist. */
+export class EscrowContractNotFoundError extends EscrowError {
+  constructor(contractId: string) {
+    super(`Contract not found: ${contractId}`, 'ESCROW_CONTRACT_NOT_FOUND')
+    this.name = 'EscrowContractNotFoundError'
+  }
+}
+
+/** The requested milestone does not exist. */
+export class EscrowMilestoneNotFoundError extends EscrowError {
+  constructor(milestoneId: string) {
+    super(`Milestone not found: ${milestoneId}`, 'ESCROW_MILESTONE_NOT_FOUND')
+    this.name = 'EscrowMilestoneNotFoundError'
+  }
+}
+
+/** The requested dispute does not exist. */
+export class EscrowDisputeNotFoundError extends EscrowError {
+  constructor(disputeId: string) {
+    super(`Dispute not found: ${disputeId}`, 'ESCROW_DISPUTE_NOT_FOUND')
+    this.name = 'EscrowDisputeNotFoundError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 409 — Conflict
+// ---------------------------------------------------------------------------
+
+/** A contract already exists for this project. */
+export class EscrowAlreadyExistsError extends EscrowError {
+  readonly existingContractId: string
+
+  constructor(projectId: string, existingContractId: string) {
+    super(
+      `A contract already exists for project ${projectId}`,
+      'ESCROW_ALREADY_EXISTS'
+    )
+    this.name = 'EscrowAlreadyExistsError'
+    this.existingContractId = existingContractId
+  }
+}
+
+/** An active dispute already exists for this contract. */
+export class EscrowDisputeAlreadyActiveError extends EscrowError {
+  readonly existingDisputeId: string
+
+  constructor(contractId: string, existingDisputeId: string) {
+    super(
+      `An active dispute already exists for contract ${contractId}`,
+      'ESCROW_DISPUTE_ALREADY_ACTIVE'
+    )
+    this.name = 'EscrowDisputeAlreadyActiveError'
+    this.existingDisputeId = existingDisputeId
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 502 — Blockchain / external service failures
+// ---------------------------------------------------------------------------
+
+/** An on-chain operation failed. */
+export class EscrowBlockchainError extends EscrowError {
+  readonly cause: unknown
+
+  constructor(message: string, cause?: unknown) {
+    super(message, 'ESCROW_BLOCKCHAIN_ERROR')
+    this.name = 'EscrowBlockchainError'
+    this.cause = cause
+  }
+}
+
+/** On-chain funding verification failed (amount mismatch or tx not found). */
+export class EscrowFundingVerificationError extends EscrowError {
+  constructor(message: string) {
+    super(message, 'ESCROW_FUNDING_VERIFICATION_FAILED')
+    this.name = 'EscrowFundingVerificationError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper — map EscrowError to HTTP status
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the appropriate HTTP status code for a given EscrowError subclass.
+ * Falls back to 500 for unknown errors.
+ */
+export function escrowErrorToHttpStatus(err: EscrowError): number {
+  switch (err.name) {
+    case 'EscrowValidationError':
+    case 'EscrowInvalidStateError':
+      return 400
+    case 'EscrowForbiddenError':
+      return 403
+    case 'EscrowContractNotFoundError':
+    case 'EscrowMilestoneNotFoundError':
+    case 'EscrowDisputeNotFoundError':
+      return 404
+    case 'EscrowAlreadyExistsError':
+    case 'EscrowDisputeAlreadyActiveError':
+      return 409
+    case 'EscrowBlockchainError':
+    case 'EscrowFundingVerificationError':
+      return 502
+    default:
+      return 500
+  }
+}

--- a/lib/escrow/index.ts
+++ b/lib/escrow/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Escrow Lifecycle Service — Public API
+ *
+ * Import from this barrel in API routes and other consumers.
+ * Internal modules (repository, blockchain adapter) are not re-exported
+ * to keep the public surface minimal and prevent controllers from bypassing
+ * the service layer.
+ *
+ * Usage:
+ *   import { escrowService, EscrowError, escrowErrorToHttpStatus } from '@/lib/escrow'
+ */
+
+// Service singleton (primary entry point)
+export { escrowService, EscrowService } from './service'
+
+// All input/output types and interfaces
+export type {
+  // Enums
+  ContractStatus,
+  EscrowStatus,
+  MilestoneStatus,
+  DisputeStatus,
+  DisputeRaisedBy,
+  // Domain objects
+  EscrowContract,
+  EscrowMilestone,
+  EscrowDispute,
+  DisputeEvidence,
+  // Service DTOs
+  MilestoneInput,
+  CreateEscrowInput,
+  CreateEscrowResult,
+  FundEscrowInput,
+  FundEscrowResult,
+  ReleaseFundsInput,
+  ReleaseFundsResult,
+  RefundEscrowInput,
+  RefundEscrowResult,
+  RaiseDisputeInput,
+  RaiseDisputeResult,
+  ResolveDisputeInput,
+  ResolveDisputeResult,
+  // Adapter / repository interfaces (for DI in tests)
+  IEscrowBlockchainAdapter,
+  IEscrowRepository,
+} from './types'
+
+// Error classes and HTTP status helper
+export {
+  EscrowError,
+  EscrowInvalidStateError,
+  EscrowValidationError,
+  EscrowForbiddenError,
+  EscrowContractNotFoundError,
+  EscrowMilestoneNotFoundError,
+  EscrowDisputeNotFoundError,
+  EscrowAlreadyExistsError,
+  EscrowDisputeAlreadyActiveError,
+  EscrowBlockchainError,
+  EscrowFundingVerificationError,
+  escrowErrorToHttpStatus,
+} from './errors'

--- a/lib/escrow/repository.ts
+++ b/lib/escrow/repository.ts
@@ -1,0 +1,372 @@
+/**
+ * Escrow Lifecycle Service — Database Repository
+ *
+ * Implements IEscrowRepository against the Neon/PostgreSQL database.
+ * All SQL lives here — the service layer never touches `sql` directly.
+ * This keeps the service pure and makes it straightforward to swap the
+ * persistence layer (e.g. for a different DB or an in-memory stub in tests).
+ */
+
+import { sql } from '@/lib/db'
+import type {
+  EscrowContract,
+  EscrowDispute,
+  EscrowMilestone,
+  EscrowStatus,
+  MilestoneStatus,
+  MilestoneInput,
+  DisputeRaisedBy,
+  DisputeEvidence,
+  IEscrowRepository,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Row → domain mappers
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rowToContract(row: any): EscrowContract {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    clientId: row.client_id,
+    freelancerId: row.freelancer_id,
+    totalAmount: row.total_amount,
+    currency: row.currency,
+    terms: row.terms ?? null,
+    termsIpfsCid: row.terms_ipfs_cid ?? null,
+    agreedAt: row.agreed_at ?? null,
+    escrowAddress: row.escrow_address ?? null,
+    escrowStatus: row.escrow_status,
+    fundedAt: row.funded_at ?? null,
+    fundingTxHash: row.funding_tx_hash ?? null,
+    status: row.status,
+    startedAt: row.started_at ?? null,
+    completedAt: row.completed_at ?? null,
+    cancelledAt: row.cancelled_at ?? null,
+    cancellationReason: row.cancellation_reason ?? null,
+    chainId: row.chain_id ?? null,
+    contractTxHash: row.contract_tx_hash ?? null,
+    activeDisputeId: row.active_dispute_id ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rowToMilestone(row: any): EscrowMilestone {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    contractId: row.contract_id ?? null,
+    title: row.title,
+    description: row.description ?? null,
+    sortOrder: row.sort_order ?? 0,
+    amount: row.amount,
+    currency: row.currency,
+    dueDate: row.due_date ?? null,
+    submittedAt: row.submitted_at ?? null,
+    approvedAt: row.approved_at ?? null,
+    paidAt: row.paid_at ?? null,
+    status: row.status,
+    escrowTxHash: row.escrow_tx_hash ?? null,
+    releaseTxHash: row.release_tx_hash ?? null,
+    deliverables: row.deliverables ?? [],
+    rejectionReason: row.rejection_reason ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rowToDispute(row: any): EscrowDispute {
+  return {
+    id: row.id,
+    contractId: row.contract_id,
+    milestoneId: row.milestone_id ?? null,
+    raisedBy: row.raised_by,
+    raisedByUserId: row.raised_by_user_id,
+    reason: row.reason,
+    desiredOutcome: row.desired_outcome ?? null,
+    evidence: row.evidence ?? [],
+    status: row.status,
+    resolverId: row.resolver_id ?? null,
+    resolutionNotes: row.resolution_notes ?? null,
+    resolvedAt: row.resolved_at ?? null,
+    clientRefundAmount: row.client_refund_amount ?? null,
+    freelancerPayoutAmount: row.freelancer_payout_amount ?? null,
+    responseDeadline: row.response_deadline ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Repository implementation
+// ---------------------------------------------------------------------------
+
+export class EscrowRepository implements IEscrowRepository {
+  // -------------------------------------------------------------------------
+  // Reads
+  // -------------------------------------------------------------------------
+
+  async getContractById(contractId: string): Promise<EscrowContract | null> {
+    const rows = await sql`
+      SELECT * FROM contracts WHERE id = ${contractId} LIMIT 1
+    `
+    return rows[0] ? rowToContract(rows[0]) : null
+  }
+
+  async getContractByProjectId(projectId: string): Promise<EscrowContract | null> {
+    const rows = await sql`
+      SELECT * FROM contracts WHERE project_id = ${projectId} LIMIT 1
+    `
+    return rows[0] ? rowToContract(rows[0]) : null
+  }
+
+  async getMilestoneById(milestoneId: string): Promise<EscrowMilestone | null> {
+    const rows = await sql`
+      SELECT * FROM milestones WHERE id = ${milestoneId} LIMIT 1
+    `
+    return rows[0] ? rowToMilestone(rows[0]) : null
+  }
+
+  async getMilestonesByContractId(contractId: string): Promise<EscrowMilestone[]> {
+    const rows = await sql`
+      SELECT * FROM milestones
+       WHERE contract_id = ${contractId}
+       ORDER BY sort_order ASC, created_at ASC
+    `
+    return rows.map(rowToMilestone)
+  }
+
+  async getDisputeById(disputeId: string): Promise<EscrowDispute | null> {
+    const rows = await sql`
+      SELECT * FROM disputes WHERE id = ${disputeId} LIMIT 1
+    `
+    return rows[0] ? rowToDispute(rows[0]) : null
+  }
+
+  async getActiveDisputeByContractId(contractId: string): Promise<EscrowDispute | null> {
+    const rows = await sql`
+      SELECT * FROM disputes
+       WHERE contract_id = ${contractId}
+         AND status NOT IN ('resolved_client', 'resolved_freelancer', 'resolved_split', 'withdrawn')
+       ORDER BY created_at DESC
+       LIMIT 1
+    `
+    return rows[0] ? rowToDispute(rows[0]) : null
+  }
+
+  async getUserWalletAddress(userId: string): Promise<string | null> {
+    const rows = await sql`
+      SELECT wallet_address FROM users WHERE id = ${userId} LIMIT 1
+    `
+    return (rows[0]?.wallet_address as string) ?? null
+  }
+
+  // -------------------------------------------------------------------------
+  // Writes
+  // -------------------------------------------------------------------------
+
+  async createContract(params: {
+    projectId: string
+    clientId: string
+    freelancerId: string
+    totalAmount: string
+    currency: string
+    terms?: string
+    escrowAddress: string
+    contractTxHash: string
+  }): Promise<EscrowContract> {
+    const rows = await sql`
+      INSERT INTO contracts (
+        project_id,
+        client_id,
+        freelancer_id,
+        total_amount,
+        currency,
+        terms,
+        escrow_address,
+        contract_tx_hash,
+        escrow_status,
+        status
+      )
+      VALUES (
+        ${params.projectId},
+        ${params.clientId},
+        ${params.freelancerId},
+        ${params.totalAmount},
+        ${params.currency},
+        ${params.terms ?? null},
+        ${params.escrowAddress},
+        ${params.contractTxHash},
+        'unfunded',
+        'pending'
+      )
+      RETURNING *
+    `
+    return rowToContract(rows[0])
+  }
+
+  async createMilestones(
+    contractId: string,
+    projectId: string,
+    milestones: MilestoneInput[]
+  ): Promise<void> {
+    for (const [index, m] of milestones.entries()) {
+      await sql`
+        INSERT INTO milestones (
+          project_id,
+          contract_id,
+          title,
+          description,
+          amount,
+          currency,
+          due_date,
+          sort_order,
+          status
+        )
+        VALUES (
+          ${projectId},
+          ${contractId},
+          ${m.title},
+          ${m.description ?? null},
+          ${m.amount},
+          'USDC',
+          ${m.dueDate ?? null},
+          ${m.sortOrder ?? index},
+          'pending'
+        )
+      `
+    }
+  }
+
+  async updateContractEscrowStatus(
+    contractId: string,
+    escrowStatus: EscrowStatus,
+    extra?: Partial<
+      Pick<
+        EscrowContract,
+        | 'fundedAt'
+        | 'fundingTxHash'
+        | 'status'
+        | 'startedAt'
+        | 'completedAt'
+        | 'cancelledAt'
+        | 'cancellationReason'
+        | 'activeDisputeId'
+      >
+    >
+  ): Promise<EscrowContract> {
+    const rows = await sql`
+      UPDATE contracts
+         SET escrow_status        = ${escrowStatus},
+             status               = COALESCE(${extra?.status ?? null}::contract_status, status),
+             funded_at            = COALESCE(${extra?.fundedAt ?? null}::timestamptz, funded_at),
+             funding_tx_hash      = COALESCE(${extra?.fundingTxHash ?? null}, funding_tx_hash),
+             started_at           = COALESCE(${extra?.startedAt ?? null}::timestamptz, started_at),
+             completed_at         = COALESCE(${extra?.completedAt ?? null}::timestamptz, completed_at),
+             cancelled_at         = COALESCE(${extra?.cancelledAt ?? null}::timestamptz, cancelled_at),
+             cancellation_reason  = COALESCE(${extra?.cancellationReason ?? null}, cancellation_reason),
+             active_dispute_id    = COALESCE(${extra?.activeDisputeId ?? null}::uuid, active_dispute_id),
+             updated_at           = NOW()
+       WHERE id = ${contractId}
+       RETURNING *
+    `
+    return rowToContract(rows[0])
+  }
+
+  async updateMilestoneStatus(
+    milestoneId: string,
+    status: MilestoneStatus,
+    extra?: Partial<
+      Pick<EscrowMilestone, 'releaseTxHash' | 'paidAt' | 'rejectionReason'>
+    >
+  ): Promise<EscrowMilestone> {
+    const rows = await sql`
+      UPDATE milestones
+         SET status           = ${status}::milestone_status,
+             release_tx_hash  = COALESCE(${extra?.releaseTxHash ?? null}, release_tx_hash),
+             paid_at          = COALESCE(${extra?.paidAt ?? null}::timestamptz, paid_at),
+             rejection_reason = COALESCE(${extra?.rejectionReason ?? null}, rejection_reason),
+             updated_at       = NOW()
+       WHERE id = ${milestoneId}
+       RETURNING *
+    `
+    return rowToMilestone(rows[0])
+  }
+
+  async createDispute(params: {
+    contractId: string
+    milestoneId?: string
+    raisedBy: DisputeRaisedBy
+    raisedByUserId: string
+    reason: string
+    desiredOutcome?: string
+    evidence?: DisputeEvidence[]
+    responseDeadline?: string
+  }): Promise<EscrowDispute> {
+    const rows = await sql`
+      INSERT INTO disputes (
+        contract_id,
+        milestone_id,
+        raised_by,
+        raised_by_user_id,
+        reason,
+        desired_outcome,
+        evidence,
+        response_deadline,
+        status
+      )
+      VALUES (
+        ${params.contractId},
+        ${params.milestoneId ?? null},
+        ${params.raisedBy}::dispute_raised_by,
+        ${params.raisedByUserId},
+        ${params.reason},
+        ${params.desiredOutcome ?? null},
+        ${JSON.stringify(params.evidence ?? [])}::jsonb,
+        ${params.responseDeadline ?? null}::timestamptz,
+        'open'
+      )
+      RETURNING *
+    `
+    return rowToDispute(rows[0])
+  }
+
+  async updateDispute(
+    disputeId: string,
+    params: Partial<
+      Pick<
+        EscrowDispute,
+        | 'status'
+        | 'resolverId'
+        | 'resolutionNotes'
+        | 'resolvedAt'
+        | 'clientRefundAmount'
+        | 'freelancerPayoutAmount'
+      >
+    >
+  ): Promise<EscrowDispute> {
+    const rows = await sql`
+      UPDATE disputes
+         SET status                    = COALESCE(${params.status ?? null}::dispute_status, status),
+             resolver_id               = COALESCE(${params.resolverId ?? null}::uuid, resolver_id),
+             resolution_notes          = COALESCE(${params.resolutionNotes ?? null}, resolution_notes),
+             resolved_at               = COALESCE(${params.resolvedAt ?? null}::timestamptz, resolved_at),
+             client_refund_amount      = COALESCE(${params.clientRefundAmount ?? null}::numeric, client_refund_amount),
+             freelancer_payout_amount  = COALESCE(${params.freelancerPayoutAmount ?? null}::numeric, freelancer_payout_amount),
+             updated_at                = NOW()
+       WHERE id = ${disputeId}
+       RETURNING *
+    `
+    return rowToDispute(rows[0])
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton export
+// ---------------------------------------------------------------------------
+
+export const escrowRepository = new EscrowRepository()

--- a/lib/escrow/service.ts
+++ b/lib/escrow/service.ts
@@ -1,0 +1,627 @@
+/**
+ * Escrow Lifecycle Service
+ *
+ * The single source of truth for all escrow operations. Controllers call this
+ * service and never touch the blockchain adapter or repository directly.
+ *
+ * Design principles:
+ *  • Pure orchestration — no SQL, no Soroban SDK imports here.
+ *  • Dependency injection via constructor — swap adapters in tests.
+ *  • Throws typed EscrowError subclasses; controllers map them to HTTP codes.
+ *  • Every state transition is validated before any side-effect is triggered.
+ *  • Extensible: DAO voting, advanced dispute handling, multi-sig, etc. can be
+ *    added by extending this class or composing additional services.
+ */
+
+import type {
+  IEscrowBlockchainAdapter,
+  IEscrowRepository,
+  CreateEscrowInput,
+  CreateEscrowResult,
+  FundEscrowInput,
+  FundEscrowResult,
+  ReleaseFundsInput,
+  ReleaseFundsResult,
+  RefundEscrowInput,
+  RefundEscrowResult,
+  RaiseDisputeInput,
+  RaiseDisputeResult,
+  ResolveDisputeInput,
+  ResolveDisputeResult,
+  EscrowContract,
+  EscrowMilestone,
+} from './types'
+
+import {
+  EscrowContractNotFoundError,
+  EscrowMilestoneNotFoundError,
+  EscrowDisputeNotFoundError,
+  EscrowAlreadyExistsError,
+  EscrowDisputeAlreadyActiveError,
+  EscrowInvalidStateError,
+  EscrowForbiddenError,
+  EscrowValidationError,
+  EscrowFundingVerificationError,
+  EscrowBlockchainError,
+} from './errors'
+
+import { sorobanEscrowAdapter } from './blockchain'
+import { escrowRepository } from './repository'
+
+// ---------------------------------------------------------------------------
+// Service class
+// ---------------------------------------------------------------------------
+
+export class EscrowService {
+  constructor(
+    private readonly blockchain: IEscrowBlockchainAdapter = sorobanEscrowAdapter,
+    private readonly repo: IEscrowRepository = escrowRepository
+  ) {}
+
+  // =========================================================================
+  // createEscrow
+  // =========================================================================
+
+  /**
+   * Deploy a new escrow smart contract and persist the contract record.
+   *
+   * Lifecycle: (none) → contract.status = 'pending', escrow_status = 'unfunded'
+   *
+   * @throws EscrowAlreadyExistsError   if a contract already exists for the project
+   * @throws EscrowValidationError      if input data is invalid
+   * @throws EscrowBlockchainError      if on-chain deployment fails
+   */
+  async createEscrow(input: CreateEscrowInput): Promise<CreateEscrowResult> {
+    // --- Validate input ---
+    this.assertValidAmount(input.totalAmount, 'totalAmount')
+    if (!input.projectId) throw new EscrowValidationError('projectId is required')
+    if (!input.clientId) throw new EscrowValidationError('clientId is required')
+    if (!input.freelancerId) throw new EscrowValidationError('freelancerId is required')
+    if (!input.clientWalletAddress) throw new EscrowValidationError('clientWalletAddress is required')
+    if (!input.freelancerWalletAddress) throw new EscrowValidationError('freelancerWalletAddress is required')
+
+    if (input.milestones && input.milestones.length > 0) {
+      this.assertMilestonesMatchTotal(input.milestones, input.totalAmount)
+    }
+
+    // --- Guard: no duplicate contract per project ---
+    const existing = await this.repo.getContractByProjectId(input.projectId)
+    if (existing) {
+      throw new EscrowAlreadyExistsError(input.projectId, existing.id)
+    }
+
+    // --- Deploy on-chain ---
+    let deployment: { contractAddress: string; txHash: string; networkPassphrase: string }
+    try {
+      deployment = await this.blockchain.deployContract({
+        clientAddress: input.clientWalletAddress,
+        freelancerAddress: input.freelancerWalletAddress,
+        totalAmount: input.totalAmount,
+        currency: input.currency ?? 'USDC',
+      })
+    } catch (err) {
+      if (err instanceof EscrowBlockchainError) throw err
+      throw new EscrowBlockchainError('Contract deployment failed', err)
+    }
+
+    // --- Persist contract ---
+    const contract = await this.repo.createContract({
+      projectId: input.projectId,
+      clientId: input.clientId,
+      freelancerId: input.freelancerId,
+      totalAmount: input.totalAmount,
+      currency: input.currency ?? 'USDC',
+      terms: input.terms,
+      escrowAddress: deployment.contractAddress,
+      contractTxHash: deployment.txHash,
+    })
+
+    // --- Persist milestones ---
+    const milestones = input.milestones ?? []
+    if (milestones.length > 0) {
+      await this.repo.createMilestones(contract.id, input.projectId, milestones)
+    }
+
+    return {
+      contract,
+      milestonesCreated: milestones.length,
+      deployTxHash: deployment.txHash,
+    }
+  }
+
+  // =========================================================================
+  // fundEscrow
+  // =========================================================================
+
+  /**
+   * Record that the client has funded the escrow contract on-chain.
+   * Verifies the funding transaction before updating state.
+   *
+   * Lifecycle: escrow_status: 'unfunded' → 'funded'
+   *            contract.status: 'pending' → 'active'
+   *
+   * @throws EscrowContractNotFoundError    if contract does not exist
+   * @throws EscrowForbiddenError           if caller is not the client
+   * @throws EscrowInvalidStateError        if escrow is already funded / refunded
+   * @throws EscrowFundingVerificationError if on-chain verification fails
+   */
+  async fundEscrow(input: FundEscrowInput): Promise<FundEscrowResult> {
+    this.assertValidAmount(input.amount, 'amount')
+    if (!input.fundingTxHash) throw new EscrowValidationError('fundingTxHash is required')
+
+    const contract = await this.requireContract(input.contractId)
+
+    // --- Authorisation: only the client can fund ---
+    await this.assertIsClient(contract, input.callerWalletAddress)
+
+    // --- State guard ---
+    if (contract.escrowStatus !== 'unfunded') {
+      throw new EscrowInvalidStateError(
+        `Cannot fund escrow: current escrow status is '${contract.escrowStatus}'`
+      )
+    }
+    if (contract.status === 'cancelled' || contract.status === 'completed') {
+      throw new EscrowInvalidStateError(
+        `Cannot fund a ${contract.status} contract`
+      )
+    }
+    if (!contract.escrowAddress) {
+      throw new EscrowInvalidStateError('Contract has no escrow address — deploy first')
+    }
+
+    // --- Verify on-chain ---
+    const verification = await this.blockchain.verifyFunding({
+      contractAddress: contract.escrowAddress,
+      txHash: input.fundingTxHash,
+      expectedAmount: input.amount,
+      currency: contract.currency,
+    })
+
+    if (!verification.verified) {
+      throw new EscrowFundingVerificationError(
+        `Funding verification failed: on-chain amount ${verification.onChainAmount} does not match expected ${input.amount}`
+      )
+    }
+
+    const now = new Date().toISOString()
+    const updated = await this.repo.updateContractEscrowStatus(
+      contract.id,
+      'funded',
+      {
+        fundedAt: now,
+        fundingTxHash: input.fundingTxHash,
+        status: 'active',
+        startedAt: now,
+      }
+    )
+
+    return { contract: updated, fundedAt: now }
+  }
+
+  // =========================================================================
+  // releaseFunds
+  // =========================================================================
+
+  /**
+   * Release funds for a specific approved milestone to the freelancer.
+   * Automatically marks the contract as 'completed' when all milestones are paid.
+   *
+   * Lifecycle: milestone.status: 'approved' → 'paid'
+   *            escrow_status: 'funded' → 'partially_released' | 'fully_released'
+   *            contract.status: 'active' → 'completed' (when all milestones paid)
+   *
+   * @throws EscrowContractNotFoundError   if contract does not exist
+   * @throws EscrowMilestoneNotFoundError  if milestone does not exist
+   * @throws EscrowForbiddenError          if caller is not the client
+   * @throws EscrowInvalidStateError       if contract or milestone is in wrong state
+   * @throws EscrowBlockchainError         if on-chain release fails
+   */
+  async releaseFunds(input: ReleaseFundsInput): Promise<ReleaseFundsResult> {
+    const contract = await this.requireContract(input.contractId)
+    const milestone = await this.requireMilestone(input.milestoneId)
+
+    // --- Authorisation: only the client releases funds ---
+    await this.assertIsClient(contract, input.callerWalletAddress)
+
+    // --- State guards ---
+    if (contract.status !== 'active') {
+      throw new EscrowInvalidStateError(
+        `Cannot release funds: contract status is '${contract.status}'`
+      )
+    }
+    if (contract.escrowStatus !== 'funded' && contract.escrowStatus !== 'partially_released') {
+      throw new EscrowInvalidStateError(
+        `Cannot release funds: escrow status is '${contract.escrowStatus}'`
+      )
+    }
+    if (milestone.contractId !== contract.id) {
+      throw new EscrowForbiddenError('Milestone does not belong to this contract')
+    }
+    if (milestone.status !== 'approved') {
+      throw new EscrowInvalidStateError(
+        `Cannot release funds: milestone status is '${milestone.status}' (must be 'approved')`
+      )
+    }
+    if (!contract.escrowAddress) {
+      throw new EscrowInvalidStateError('Contract has no escrow address')
+    }
+
+    // --- Resolve freelancer wallet ---
+    const freelancerWallet = await this.repo.getUserWalletAddress(contract.freelancerId)
+    if (!freelancerWallet) {
+      throw new EscrowValidationError('Freelancer wallet address not found')
+    }
+
+    // --- Trigger on-chain release ---
+    let release: { txHash: string }
+    try {
+      release = await this.blockchain.releaseMilestoneFunds({
+        contractAddress: contract.escrowAddress,
+        milestoneId: milestone.id,
+        recipientAddress: freelancerWallet,
+        amount: milestone.amount,
+        currency: milestone.currency,
+      })
+    } catch (err) {
+      if (err instanceof EscrowBlockchainError) throw err
+      throw new EscrowBlockchainError('Failed to release milestone funds on-chain', err)
+    }
+
+    const now = new Date().toISOString()
+
+    // --- Update milestone ---
+    const updatedMilestone = await this.repo.updateMilestoneStatus(
+      milestone.id,
+      'paid',
+      { releaseTxHash: release.txHash, paidAt: now }
+    )
+
+    // --- Determine new escrow / contract status ---
+    const allMilestones = await this.repo.getMilestonesByContractId(contract.id)
+    const allPaid = allMilestones.every(
+      (m) => m.id === milestone.id ? true : m.status === 'paid'
+    )
+
+    const newEscrowStatus = allPaid ? 'fully_released' : 'partially_released'
+    const updatedContract = await this.repo.updateContractEscrowStatus(
+      contract.id,
+      newEscrowStatus,
+      allPaid ? { status: 'completed', completedAt: now } : undefined
+    )
+
+    return {
+      milestone: updatedMilestone,
+      contract: updatedContract,
+      releaseTxHash: release.txHash,
+      allMilestonesPaid: allPaid,
+    }
+  }
+
+  // =========================================================================
+  // refundEscrow
+  // =========================================================================
+
+  /**
+   * Refund all remaining escrowed funds back to the client.
+   * Can be triggered by the client (cancellation) or an admin (dispute resolution).
+   *
+   * Lifecycle: escrow_status → 'refunded'
+   *            contract.status → 'cancelled'
+   *
+   * @throws EscrowContractNotFoundError  if contract does not exist
+   * @throws EscrowForbiddenError         if caller is neither client nor admin
+   * @throws EscrowInvalidStateError      if escrow is not in a refundable state
+   * @throws EscrowBlockchainError        if on-chain refund fails
+   */
+  async refundEscrow(input: RefundEscrowInput): Promise<RefundEscrowResult> {
+    if (!input.reason?.trim()) throw new EscrowValidationError('reason is required')
+
+    const contract = await this.requireContract(input.contractId)
+
+    // --- Authorisation: client or admin ---
+    await this.assertIsClientOrAdmin(contract, input.callerWalletAddress)
+
+    // --- State guard ---
+    const refundableEscrowStatuses = ['funded', 'partially_released']
+    if (!refundableEscrowStatuses.includes(contract.escrowStatus)) {
+      throw new EscrowInvalidStateError(
+        `Cannot refund: escrow status is '${contract.escrowStatus}'`
+      )
+    }
+    if (contract.status === 'completed' || contract.status === 'cancelled') {
+      throw new EscrowInvalidStateError(
+        `Cannot refund a ${contract.status} contract`
+      )
+    }
+    if (!contract.escrowAddress) {
+      throw new EscrowInvalidStateError('Contract has no escrow address')
+    }
+
+    // --- Resolve client wallet ---
+    const clientWallet = await this.repo.getUserWalletAddress(contract.clientId)
+    if (!clientWallet) {
+      throw new EscrowValidationError('Client wallet address not found')
+    }
+
+    // --- Trigger on-chain refund ---
+    let refund: { txHash: string }
+    try {
+      refund = await this.blockchain.refundEscrow({
+        contractAddress: contract.escrowAddress,
+        clientAddress: clientWallet,
+        amount: contract.totalAmount,
+        currency: contract.currency,
+      })
+    } catch (err) {
+      if (err instanceof EscrowBlockchainError) throw err
+      throw new EscrowBlockchainError('Failed to refund escrow on-chain', err)
+    }
+
+    const now = new Date().toISOString()
+    const updatedContract = await this.repo.updateContractEscrowStatus(
+      contract.id,
+      'refunded',
+      {
+        status: 'cancelled',
+        cancelledAt: now,
+        cancellationReason: input.reason,
+      }
+    )
+
+    return { contract: updatedContract, refundTxHash: refund.txHash }
+  }
+
+  // =========================================================================
+  // raiseDispute
+  // =========================================================================
+
+  /**
+   * Open a dispute on an active contract.
+   * Transitions the contract to 'disputed' status and blocks fund releases.
+   *
+   * Lifecycle: contract.status: 'active' → 'disputed'
+   *            dispute.status: 'open'
+   *
+   * @throws EscrowContractNotFoundError       if contract does not exist
+   * @throws EscrowForbiddenError              if caller is not a party to the contract
+   * @throws EscrowInvalidStateError           if contract is not in a disputable state
+   * @throws EscrowDisputeAlreadyActiveError   if an open dispute already exists
+   */
+  async raiseDispute(input: RaiseDisputeInput): Promise<RaiseDisputeResult> {
+    if (!input.reason?.trim()) throw new EscrowValidationError('reason is required')
+
+    const contract = await this.requireContract(input.contractId)
+
+    // --- State guard ---
+    const disputableStatuses = ['active', 'paused']
+    if (!disputableStatuses.includes(contract.status)) {
+      throw new EscrowInvalidStateError(
+        `Cannot raise dispute: contract status is '${contract.status}'`
+      )
+    }
+
+    // --- Guard: no duplicate active dispute ---
+    const existingDispute = await this.repo.getActiveDisputeByContractId(contract.id)
+    if (existingDispute) {
+      throw new EscrowDisputeAlreadyActiveError(contract.id, existingDispute.id)
+    }
+
+    // --- Validate milestone belongs to contract (if provided) ---
+    if (input.milestoneId) {
+      const milestone = await this.repo.getMilestoneById(input.milestoneId)
+      if (!milestone) throw new EscrowMilestoneNotFoundError(input.milestoneId)
+      if (milestone.contractId !== contract.id) {
+        throw new EscrowForbiddenError('Milestone does not belong to this contract')
+      }
+    }
+
+    // --- Create dispute ---
+    const dispute = await this.repo.createDispute({
+      contractId: contract.id,
+      milestoneId: input.milestoneId,
+      raisedBy: input.raisedBy,
+      raisedByUserId: input.raisedByUserId,
+      reason: input.reason,
+      desiredOutcome: input.desiredOutcome,
+      evidence: input.evidence,
+      responseDeadline: input.responseDeadline,
+    })
+
+    // --- Transition contract to disputed ---
+    const updatedContract = await this.repo.updateContractEscrowStatus(
+      contract.id,
+      contract.escrowStatus, // escrow_status unchanged — funds stay locked
+      {
+        status: 'disputed',
+        activeDisputeId: dispute.id,
+      }
+    )
+
+    return { dispute, contract: updatedContract }
+  }
+
+  // =========================================================================
+  // resolveDispute
+  // =========================================================================
+
+  /**
+   * Resolve an open dispute (admin only).
+   * Depending on the outcome, funds are released to the freelancer, refunded
+   * to the client, or split between both parties.
+   *
+   * Lifecycle: dispute.status → resolved_* | withdrawn
+   *            contract.status → 'active' | 'cancelled' | 'completed'
+   *
+   * Extensibility note: DAO voting can be wired in here by adding a
+   * `daoVoteId` field to ResolveDisputeInput and verifying the vote result
+   * before proceeding with the resolution.
+   *
+   * @throws EscrowDisputeNotFoundError   if dispute does not exist
+   * @throws EscrowContractNotFoundError  if related contract does not exist
+   * @throws EscrowInvalidStateError      if dispute is already resolved
+   * @throws EscrowValidationError        if split amounts are missing for split outcome
+   */
+  async resolveDispute(input: ResolveDisputeInput): Promise<ResolveDisputeResult> {
+    if (!input.resolutionNotes?.trim()) {
+      throw new EscrowValidationError('resolutionNotes is required')
+    }
+
+    const dispute = await this.repo.getDisputeById(input.disputeId)
+    if (!dispute) throw new EscrowDisputeNotFoundError(input.disputeId)
+
+    // --- State guard ---
+    const resolvableStatuses = ['open', 'under_review', 'escalated']
+    if (!resolvableStatuses.includes(dispute.status)) {
+      throw new EscrowInvalidStateError(
+        `Cannot resolve dispute: current status is '${dispute.status}'`
+      )
+    }
+
+    // --- Validate split amounts ---
+    if (input.outcome === 'resolved_split') {
+      if (!input.clientRefundAmount || !input.freelancerPayoutAmount) {
+        throw new EscrowValidationError(
+          'clientRefundAmount and freelancerPayoutAmount are required for split resolution'
+        )
+      }
+      this.assertValidAmount(input.clientRefundAmount, 'clientRefundAmount')
+      this.assertValidAmount(input.freelancerPayoutAmount, 'freelancerPayoutAmount')
+    }
+
+    const contract = await this.requireContract(dispute.contractId)
+    const now = new Date().toISOString()
+
+    // --- Update dispute ---
+    const updatedDispute = await this.repo.updateDispute(dispute.id, {
+      status: input.outcome,
+      resolverId: input.resolverUserId,
+      resolutionNotes: input.resolutionNotes,
+      resolvedAt: now,
+      clientRefundAmount: input.clientRefundAmount,
+      freelancerPayoutAmount: input.freelancerPayoutAmount,
+    })
+
+    // --- Determine new contract status based on outcome ---
+    let newContractStatus: EscrowContract['status']
+    switch (input.outcome) {
+      case 'resolved_client':
+      case 'withdrawn':
+        // Funds go back to client → contract cancelled
+        newContractStatus = 'cancelled'
+        break
+      case 'resolved_freelancer':
+        // Funds go to freelancer → contract completed
+        newContractStatus = 'completed'
+        break
+      case 'resolved_split':
+        // Partial release + partial refund → contract completed
+        newContractStatus = 'completed'
+        break
+    }
+
+    const updatedContract = await this.repo.updateContractEscrowStatus(
+      contract.id,
+      contract.escrowStatus,
+      {
+        status: newContractStatus,
+        activeDisputeId: undefined, // clear active dispute
+        ...(newContractStatus === 'cancelled'
+          ? { cancelledAt: now, cancellationReason: `Dispute resolved: ${input.outcome}` }
+          : { completedAt: now }),
+      }
+    )
+
+    return { dispute: updatedDispute, contract: updatedContract }
+  }
+
+  // =========================================================================
+  // Private helpers
+  // =========================================================================
+
+  private async requireContract(contractId: string): Promise<EscrowContract> {
+    const contract = await this.repo.getContractById(contractId)
+    if (!contract) throw new EscrowContractNotFoundError(contractId)
+    return contract
+  }
+
+  private async requireMilestone(milestoneId: string): Promise<EscrowMilestone> {
+    const milestone = await this.repo.getMilestoneById(milestoneId)
+    if (!milestone) throw new EscrowMilestoneNotFoundError(milestoneId)
+    return milestone
+  }
+
+  /**
+   * Assert that the caller's wallet address matches the contract's client.
+   */
+  private async assertIsClient(
+    contract: EscrowContract,
+    callerWalletAddress: string
+  ): Promise<void> {
+    const clientWallet = await this.repo.getUserWalletAddress(contract.clientId)
+    if (!clientWallet || clientWallet.toLowerCase() !== callerWalletAddress.toLowerCase()) {
+      throw new EscrowForbiddenError('Only the contract client can perform this action')
+    }
+  }
+
+  /**
+   * Assert that the caller is either the client or an admin.
+   * Admin check is done by looking up the user's role in the DB.
+   */
+  private async assertIsClientOrAdmin(
+    contract: EscrowContract,
+    callerWalletAddress: string
+  ): Promise<void> {
+    const clientWallet = await this.repo.getUserWalletAddress(contract.clientId)
+    if (clientWallet && clientWallet.toLowerCase() === callerWalletAddress.toLowerCase()) {
+      return // caller is the client
+    }
+
+    // Check if caller is an admin via the DB
+    const { sql } = await import('@/lib/db')
+    const rows = await sql`
+      SELECT role FROM users WHERE wallet_address = ${callerWalletAddress} LIMIT 1
+    `
+    if (rows[0]?.role === 'admin') return
+
+    throw new EscrowForbiddenError(
+      'Only the contract client or an admin can perform this action'
+    )
+  }
+
+  /**
+   * Validate that a string represents a positive finite number.
+   */
+  private assertValidAmount(value: string, field: string): void {
+    const n = Number(value)
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new EscrowValidationError(`${field} must be a positive number string`)
+    }
+  }
+
+  /**
+   * Validate that the sum of milestone amounts equals the contract total.
+   * Allows a small floating-point tolerance (0.000001).
+   */
+  private assertMilestonesMatchTotal(
+    milestones: Array<{ amount: string }>,
+    totalAmount: string
+  ): void {
+    const sum = milestones.reduce((acc, m) => acc + Number(m.amount), 0)
+    const total = Number(totalAmount)
+    if (Math.abs(sum - total) > 0.000001) {
+      throw new EscrowValidationError(
+        `Sum of milestone amounts (${sum}) must equal totalAmount (${total})`
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton export — import this in API routes
+// ---------------------------------------------------------------------------
+
+/**
+ * Default service instance using the production blockchain adapter and DB repo.
+ * In tests, construct a new EscrowService with mock dependencies instead.
+ */
+export const escrowService = new EscrowService()

--- a/lib/escrow/types.ts
+++ b/lib/escrow/types.ts
@@ -1,0 +1,358 @@
+/**
+ * Escrow Lifecycle Service — Shared Types
+ *
+ * All domain types used across the escrow service layer. Keeping types in a
+ * dedicated module makes them easy to import without pulling in side-effects
+ * from the service or repository modules.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums (mirror the DB enums so TypeScript can enforce valid values)
+// ---------------------------------------------------------------------------
+
+export type ContractStatus =
+  | 'pending'
+  | 'active'
+  | 'paused'
+  | 'completed'
+  | 'cancelled'
+  | 'disputed'
+
+export type EscrowStatus =
+  | 'unfunded'
+  | 'funded'
+  | 'partially_released'
+  | 'fully_released'
+  | 'refunded'
+
+export type MilestoneStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'submitted'
+  | 'approved'
+  | 'rejected'
+  | 'paid'
+
+export type DisputeStatus =
+  | 'open'
+  | 'under_review'
+  | 'resolved_client'
+  | 'resolved_freelancer'
+  | 'resolved_split'
+  | 'withdrawn'
+  | 'escalated'
+
+export type DisputeRaisedBy = 'client' | 'freelancer' | 'admin'
+
+// ---------------------------------------------------------------------------
+// Core domain objects
+// ---------------------------------------------------------------------------
+
+export interface EscrowContract {
+  id: string
+  projectId: string
+  clientId: string
+  freelancerId: string
+  totalAmount: string
+  currency: string
+  terms: string | null
+  termsIpfsCid: string | null
+  agreedAt: string | null
+  escrowAddress: string | null
+  escrowStatus: EscrowStatus
+  fundedAt: string | null
+  fundingTxHash: string | null
+  status: ContractStatus
+  startedAt: string | null
+  completedAt: string | null
+  cancelledAt: string | null
+  cancellationReason: string | null
+  chainId: number | null
+  contractTxHash: string | null
+  activeDisputeId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface EscrowMilestone {
+  id: string
+  projectId: string
+  contractId: string | null
+  title: string
+  description: string | null
+  sortOrder: number
+  amount: string
+  currency: string
+  dueDate: string | null
+  submittedAt: string | null
+  approvedAt: string | null
+  paidAt: string | null
+  status: MilestoneStatus
+  escrowTxHash: string | null
+  releaseTxHash: string | null
+  deliverables: unknown[]
+  rejectionReason: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface EscrowDispute {
+  id: string
+  contractId: string
+  milestoneId: string | null
+  raisedBy: DisputeRaisedBy
+  raisedByUserId: string
+  reason: string
+  desiredOutcome: string | null
+  evidence: DisputeEvidence[]
+  status: DisputeStatus
+  resolverId: string | null
+  resolutionNotes: string | null
+  resolvedAt: string | null
+  clientRefundAmount: string | null
+  freelancerPayoutAmount: string | null
+  responseDeadline: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface DisputeEvidence {
+  type: string
+  url: string
+  label?: string
+}
+
+// ---------------------------------------------------------------------------
+// Service input / output DTOs
+// ---------------------------------------------------------------------------
+
+export interface MilestoneInput {
+  title: string
+  description?: string
+  amount: string
+  dueDate?: string
+  sortOrder?: number
+}
+
+/** Input for createEscrow */
+export interface CreateEscrowInput {
+  projectId: string
+  clientId: string
+  freelancerId: string
+  clientWalletAddress: string
+  freelancerWalletAddress: string
+  totalAmount: string
+  currency: string
+  terms?: string
+  milestones?: MilestoneInput[]
+}
+
+/** Result returned from createEscrow */
+export interface CreateEscrowResult {
+  contract: EscrowContract
+  milestonesCreated: number
+  /** On-chain transaction hash from deployment */
+  deployTxHash: string
+}
+
+/** Input for fundEscrow */
+export interface FundEscrowInput {
+  contractId: string
+  /** Wallet address of the party funding (must be the client) */
+  callerWalletAddress: string
+  /** On-chain transaction hash proving the funding transfer */
+  fundingTxHash: string
+  /** Amount funded — validated against contract total */
+  amount: string
+}
+
+/** Result returned from fundEscrow */
+export interface FundEscrowResult {
+  contract: EscrowContract
+  fundedAt: string
+}
+
+/** Input for releaseFunds (per milestone) */
+export interface ReleaseFundsInput {
+  contractId: string
+  milestoneId: string
+  /** Wallet address of the caller — must be the client */
+  callerWalletAddress: string
+}
+
+/** Result returned from releaseFunds */
+export interface ReleaseFundsResult {
+  milestone: EscrowMilestone
+  contract: EscrowContract
+  releaseTxHash: string
+  allMilestonesPaid: boolean
+}
+
+/** Input for refundEscrow */
+export interface RefundEscrowInput {
+  contractId: string
+  /** Wallet address of the caller — client or admin */
+  callerWalletAddress: string
+  reason: string
+}
+
+/** Result returned from refundEscrow */
+export interface RefundEscrowResult {
+  contract: EscrowContract
+  refundTxHash: string
+}
+
+/** Input for raiseDispute */
+export interface RaiseDisputeInput {
+  contractId: string
+  milestoneId?: string
+  raisedByUserId: string
+  raisedBy: DisputeRaisedBy
+  reason: string
+  desiredOutcome?: string
+  evidence?: DisputeEvidence[]
+  /** ISO date string for arbitration response deadline */
+  responseDeadline?: string
+}
+
+/** Result returned from raiseDispute */
+export interface RaiseDisputeResult {
+  dispute: EscrowDispute
+  contract: EscrowContract
+}
+
+/** Input for resolveDispute (admin only) */
+export interface ResolveDisputeInput {
+  disputeId: string
+  resolverUserId: string
+  outcome: 'resolved_client' | 'resolved_freelancer' | 'resolved_split' | 'withdrawn'
+  resolutionNotes: string
+  /** Required when outcome = 'resolved_split' */
+  clientRefundAmount?: string
+  /** Required when outcome = 'resolved_split' */
+  freelancerPayoutAmount?: string
+}
+
+/** Result returned from resolveDispute */
+export interface ResolveDisputeResult {
+  dispute: EscrowDispute
+  contract: EscrowContract
+}
+
+// ---------------------------------------------------------------------------
+// Blockchain adapter interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstraction over the Soroban/Stellar blockchain layer.
+ * Swap the real implementation for a stub in tests without touching service logic.
+ */
+export interface IEscrowBlockchainAdapter {
+  /**
+   * Deploy a new escrow smart contract on-chain.
+   * Returns the deployed contract address and the deployment tx hash.
+   */
+  deployContract(params: {
+    clientAddress: string
+    freelancerAddress: string
+    totalAmount: string
+    currency: string
+  }): Promise<{ contractAddress: string; txHash: string; networkPassphrase: string }>
+
+  /**
+   * Verify that a funding transaction is valid and the escrow contract
+   * has received the expected amount on-chain.
+   */
+  verifyFunding(params: {
+    contractAddress: string
+    txHash: string
+    expectedAmount: string
+    currency: string
+  }): Promise<{ verified: boolean; onChainAmount: string }>
+
+  /**
+   * Invoke the release function on the escrow contract for a specific milestone.
+   * Returns the release transaction hash.
+   */
+  releaseMilestoneFunds(params: {
+    contractAddress: string
+    milestoneId: string
+    recipientAddress: string
+    amount: string
+    currency: string
+  }): Promise<{ txHash: string }>
+
+  /**
+   * Invoke the refund function on the escrow contract, returning all
+   * remaining funds to the client.
+   */
+  refundEscrow(params: {
+    contractAddress: string
+    clientAddress: string
+    amount: string
+    currency: string
+  }): Promise<{ txHash: string }>
+}
+
+// ---------------------------------------------------------------------------
+// Repository interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstraction over the database layer for escrow operations.
+ * Enables unit testing the service without a real DB connection.
+ */
+export interface IEscrowRepository {
+  getContractById(contractId: string): Promise<EscrowContract | null>
+  getContractByProjectId(projectId: string): Promise<EscrowContract | null>
+  getMilestoneById(milestoneId: string): Promise<EscrowMilestone | null>
+  getMilestonesByContractId(contractId: string): Promise<EscrowMilestone[]>
+  getDisputeById(disputeId: string): Promise<EscrowDispute | null>
+  getActiveDisputeByContractId(contractId: string): Promise<EscrowDispute | null>
+  getUserWalletAddress(userId: string): Promise<string | null>
+
+  createContract(params: {
+    projectId: string
+    clientId: string
+    freelancerId: string
+    totalAmount: string
+    currency: string
+    terms?: string
+    escrowAddress: string
+    contractTxHash: string
+  }): Promise<EscrowContract>
+
+  createMilestones(
+    contractId: string,
+    projectId: string,
+    milestones: MilestoneInput[]
+  ): Promise<void>
+
+  updateContractEscrowStatus(
+    contractId: string,
+    escrowStatus: EscrowStatus,
+    extra?: Partial<Pick<EscrowContract, 'fundedAt' | 'fundingTxHash' | 'status' | 'startedAt' | 'completedAt' | 'cancelledAt' | 'cancellationReason' | 'activeDisputeId'>>
+  ): Promise<EscrowContract>
+
+  updateMilestoneStatus(
+    milestoneId: string,
+    status: MilestoneStatus,
+    extra?: Partial<Pick<EscrowMilestone, 'releaseTxHash' | 'paidAt' | 'rejectionReason'>>
+  ): Promise<EscrowMilestone>
+
+  createDispute(params: {
+    contractId: string
+    milestoneId?: string
+    raisedBy: DisputeRaisedBy
+    raisedByUserId: string
+    reason: string
+    desiredOutcome?: string
+    evidence?: DisputeEvidence[]
+    responseDeadline?: string
+  }): Promise<EscrowDispute>
+
+  updateDispute(
+    disputeId: string,
+    params: Partial<Pick<EscrowDispute, 'status' | 'resolverId' | 'resolutionNotes' | 'resolvedAt' | 'clientRefundAmount' | 'freelancerPayoutAmount'>>
+  ): Promise<EscrowDispute>
+}


### PR DESCRIPTION
Closes #51 

## Summary

Implements the escrow lifecycle service layer, abstracting all blockchain
logic away from controllers.

## Changes

### Service Layer (`lib/escrow/`)
- `types.ts` — All shared types, DTOs, and interfaces (IEscrowBlockchainAdapter, IEscrowRepository)
- `errors.ts` — Typed domain errors with escrowErrorToHttpStatus() helper
- `blockchain.ts` — SorobanEscrowAdapter encapsulating every on-chain call
- `repository.ts` — EscrowRepository with all SQL isolated from service logic
- `service.ts` — EscrowService: createEscrow, fundEscrow, releaseFunds, refundEscrow, raiseDispute, resolveDispute
- `index.ts` — Clean public barrel export

### API Routes (`app/api/escrow/`)
| Route | Method | Action |
|-------|--------|--------|
| /api/escrow/create | POST | Deploy escrow contract |
| /api/escrow/fund | POST | Record on-chain funding |
| /api/escrow/release | POST | Release milestone funds to freelancer |
| /api/escrow/refund | POST | Refund escrow to client |
| /api/escrow/dispute | POST | Raise a dispute |
| /api/escrow/dispute/resolve | POST | Admin resolves dispute |

## Architecture
- Dependency injection — swap blockchain/repo adapters in tests
- State machine enforcement — validates status before any side-effect
- Typed errors — clean HTTP mapping via escrowErrorToHttpStatus()
- Non-breaking — existing contracts/deploy route untouched
