### PR TITLE
fix: Stellar Testnet Integration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,8 @@ import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
 import { ThemeProvider } from "@/components/theme-provider" 
 import { Toaster } from "@/components/ui/sonner"
+import { StellarWalletProvider } from "@/components/wallet-provider"
+import { NetworkBanner } from "@/components/network-banner"
 
 export const metadata: Metadata = {
   title: 'TaskChain',
@@ -43,9 +45,12 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
-          <Toaster expand closeButton />
-          <Analytics />
+          <StellarWalletProvider>
+            <NetworkBanner />
+            {children}
+            <Toaster expand closeButton />
+            <Analytics />
+          </StellarWalletProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,42 +2,56 @@
 
 import React, { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { isConnected, requestAccess, getAddress, signMessage } from '@stellar/freighter-api'
+import { signMessage } from '@stellar/freighter-api'
 import { Button } from '@/components/ui/button'
-import { Wallet, LogOut, AlertCircle, Loader2, ArrowLeft, FlaskConical } from 'lucide-react'
+import {
+  Wallet,
+  LogOut,
+  AlertCircle,
+  Loader2,
+  ArrowLeft,
+  FlaskConical,
+  AlertTriangle,
+} from 'lucide-react'
 import Link from 'next/link'
+import {
+  useStellarWallet,
+  truncateStellarAddress,
+} from '@/components/wallet-provider'
 
 const IS_DEV = process.env.NODE_ENV !== 'production'
 
 export default function LoginPage() {
   const router = useRouter()
-  const [address, setAddress] = useState<string | null>(null)
+
+  // ── Wallet context ────────────────────────────────────────────────────────
+  const {
+    address,
+    isConnected: walletIsConnected,
+    isConnecting,
+    isWrongNetwork,
+    network,
+    connect,
+    disconnect,
+  } = useStellarWallet()
+
+  // ── Local state ──────────────────────────────────────────────────────────
   const [isInitializing, setIsInitializing] = useState(true)
-  const [isConnecting, setIsConnecting] = useState(false)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [isMocking, setIsMocking] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Initialize session from local storage on mount
+  // ── Session check on mount ────────────────────────────────────────────────
   useEffect(() => {
-    const initSession = async () => {
+    const checkSession = async () => {
       try {
         const savedAddress = localStorage.getItem('stellar_wallet_address')
-        if (savedAddress) {
-          // Verify if still connected
-          const connectedResponse = await isConnected()
-          if (connectedResponse.isConnected) {
-            // Also check if backend session is still active
-            const meRes = await fetch('/api/auth/me')
-            if (meRes.ok) {
-              setAddress(savedAddress)
-              router.push('/dashboard')
-              return
-            }
+        if (savedAddress && walletIsConnected) {
+          const meRes = await fetch('/api/auth/me')
+          if (meRes.ok) {
+            router.push('/dashboard')
+            return
           }
-          // Clear if not fully verified
-          localStorage.removeItem('stellar_wallet_address')
-          localStorage.removeItem('tc_dev_access_token')
         }
       } catch (err) {
         console.error('Failed to initialize wallet session:', err)
@@ -46,48 +60,42 @@ export default function LoginPage() {
       }
     }
 
-    // Slight delay to ensure Freighter extension is loaded
-    setTimeout(initSession, 500)
-  }, [router])
+    // Small delay to let provider's first sync complete
+    const t = setTimeout(checkSession, 700)
+    return () => clearTimeout(t)
+  }, [router, walletIsConnected])
 
+  // ── Step 1: Connect wallet ────────────────────────────────────────────────
   const handleConnect = async () => {
     setError(null)
-    setIsConnecting(true)
-    setStatusMessage('Connecting wallet...')
+    // Delegates to the global provider (handles requestAccess + address/network sync)
+    await connect()
+  }
+
+  // ── Step 2: Sign message & authenticate ─────────────────────────────────
+  const handleSign = async () => {
+    setError(null)
+
+    if (!address) {
+      setError('No wallet connected. Please connect Freighter first.')
+      return
+    }
+
+    // Block if on the wrong network
+    if (isWrongNetwork) {
+      setError(
+        `Wrong network detected (${network}). Please switch your Freighter wallet to Stellar Testnet and try again.`
+      )
+      return
+    }
+
     try {
-      // Check if Freighter is installed
-      const connectedResponse = await isConnected()
-      if (connectedResponse.error && !connectedResponse.isConnected) {
-        throw new Error(connectedResponse.error.message || 'Freighter wallet not detected. Please install the extension.')
-      }
-
-      // Request connection
-      const accessResponse = await requestAccess()
-      if (accessResponse.error) {
-        throw new Error(accessResponse.error.message || 'Connection request was rejected.')
-      }
-
-      let walletAddress = accessResponse.address;
-
-      // Fallback if address is missing but no error was caught
-      if (!walletAddress) {
-        const addressResponse = await getAddress()
-        if (addressResponse.error) {
-          throw new Error(addressResponse.error.message || 'Failed to retrieve wallet address.')
-        }
-        walletAddress = addressResponse.address
-      }
-
-      if (!walletAddress) {
-        throw new Error('Failed to retrieve wallet address from Freighter.')
-      }
-
       // 1. Fetch Nonce & Message
       setStatusMessage('Requesting authentication message...')
       const nonceRes = await fetch('/api/auth/nonce', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ walletAddress }),
+        body: JSON.stringify({ walletAddress: address }),
       })
       const nonceData = await nonceRes.json()
       if (!nonceRes.ok) {
@@ -99,13 +107,15 @@ export default function LoginPage() {
       // 2. Request signature via Freighter signMessage
       setStatusMessage('Approve signature request...')
       const signResponse = await signMessage(message)
-      
+
       let signature: string | undefined
       if (typeof signResponse === 'string') {
         signature = signResponse
       } else if (signResponse && typeof signResponse === 'object') {
         if (signResponse.error) {
-          throw new Error(signResponse.error.message || signResponse.error || 'Message signing was rejected.')
+          throw new Error(
+            signResponse.error.message || signResponse.error || 'Message signing was rejected.'
+          )
         }
         signature = signResponse.signedMessage
       }
@@ -119,12 +129,7 @@ export default function LoginPage() {
       const verifyRes = await fetch('/api/auth/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          walletAddress,
-          nonce,
-          signature,
-          message,
-        }),
+        body: JSON.stringify({ walletAddress: address, nonce, signature, message }),
       })
 
       const verifyData = await verifyRes.json()
@@ -132,22 +137,21 @@ export default function LoginPage() {
         throw new Error(verifyData?.error || 'Signature verification failed.')
       }
 
-      // 4. Set local storage & redirect
-      setAddress(walletAddress)
-      localStorage.setItem('stellar_wallet_address', walletAddress)
+      // 4. Persist & redirect
+      localStorage.setItem('stellar_wallet_address', address)
       if (verifyData.accessToken) {
         localStorage.setItem('tc_dev_access_token', verifyData.accessToken)
       }
       router.push('/dashboard')
-    } catch (err: any) {
-      console.error('Connection error:', err)
-      setError(err?.message || 'Unable to connect wallet. Please try again.')
+    } catch (err: unknown) {
+      console.error('Sign-in error:', err)
+      setError(err instanceof Error ? err.message : 'Unable to authenticate. Please try again.')
     } finally {
-      setIsConnecting(false)
       setStatusMessage(null)
     }
   }
 
+  // ── Dev-only mock login bypass ─────────────────────────────────────────
   const handleMockLogin = async () => {
     setError(null)
     setIsMocking(true)
@@ -155,10 +159,7 @@ export default function LoginPage() {
       const res = await fetch('/api/auth/mock', { method: 'POST' })
       const data = await res.json()
       if (!res.ok) throw new Error(data?.error ?? 'Mock auth failed')
-      setAddress(data.walletAddress)
       localStorage.setItem('stellar_wallet_address', data.walletAddress)
-      // Store the access token so the wizard can send it as a Bearer header
-      // in case the httpOnly cookie isn't forwarded by the browser in dev.
       if (data.accessToken) {
         localStorage.setItem('tc_dev_access_token', data.accessToken)
       }
@@ -171,17 +172,11 @@ export default function LoginPage() {
   }
 
   const handleDisconnect = () => {
-    setAddress(null)
-    localStorage.removeItem('stellar_wallet_address')
-    localStorage.removeItem('tc_dev_access_token')
+    disconnect()
     setError(null)
   }
 
-  const formatAddress = (addr: string) => {
-    if (!addr || addr.length <= 10) return addr;
-    return `${addr.substring(0, 5)}...${addr.substring(addr.length - 4)}`
-  }
-
+  // ── Render ─────────────────────────────────────────────────────────────────
   return (
     <main className="min-h-screen flex items-center justify-center bg-background p-4 relative overflow-hidden">
       {/* Back button */}
@@ -194,16 +189,18 @@ export default function LoginPage() {
         </Button>
       </div>
 
-      {/* Background decorations matching the app's aesthetic */}
+      {/* Background decorations */}
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-primary/20 rounded-full blur-[120px] opacity-20 pointer-events-none" />
       <div className="absolute top-0 right-0 w-[400px] h-[400px] bg-accent/20 rounded-full blur-[100px] opacity-20 pointer-events-none" />
 
       <div className="relative z-10 w-full max-w-md bg-card border border-border/50 rounded-2xl p-8 shadow-2xl backdrop-blur-sm">
         <div className="flex flex-col items-center text-center space-y-6">
+          {/* Icon */}
           <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center border border-primary/20">
             <Wallet className="w-8 h-8 text-primary" />
           </div>
 
+          {/* Header */}
           <div className="space-y-2">
             <h1 className="text-2xl font-bold tracking-tight text-card-foreground">Connect Wallet</h1>
             <p className="text-sm text-muted-foreground">
@@ -211,6 +208,7 @@ export default function LoginPage() {
             </p>
           </div>
 
+          {/* Error banner */}
           {error && (
             <div className="w-full p-4 rounded-lg bg-destructive/10 border border-destructive/20 flex items-start space-x-3 text-left">
               <AlertCircle className="w-5 h-5 text-destructive shrink-0 mt-0.5" />
@@ -218,31 +216,80 @@ export default function LoginPage() {
             </div>
           )}
 
+          {/* ── State: Initializing ─────────────────────────────────────── */}
           {isInitializing ? (
             <div className="w-full h-12 flex items-center justify-center text-muted-foreground">
               <Loader2 className="w-5 h-5 animate-spin" />
             </div>
+
           ) : address ? (
+            /* ── State: Wallet connected ─────────────────────────────── */
             <div className="w-full space-y-4">
+
+              {/* Connected wallet info */}
               <div className="p-4 rounded-lg bg-secondary/50 border border-border flex items-center justify-between">
-                <span className="text-sm font-medium text-foreground">Connected</span>
+                <div className="flex items-center gap-2">
+                  <span className="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
+                  <span className="text-sm font-medium text-foreground">Connected</span>
+                </div>
                 <span className="text-sm font-mono bg-background px-2 py-1 rounded border border-border/50">
-                  {formatAddress(address)}
+                  {truncateStellarAddress(address)}
                 </span>
               </div>
 
+              {/* Wrong-network warning */}
+              {isWrongNetwork && (
+                <div className="w-full p-4 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-start gap-3 text-left">
+                  <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-sm font-semibold text-amber-600 dark:text-amber-400">Wrong Network</p>
+                    <p className="text-xs text-amber-700/80 dark:text-amber-300/80 mt-0.5">
+                      Your Freighter wallet is set to <strong>{network}</strong>. TaskChain requires{' '}
+                      <strong>Stellar Testnet</strong>. Open Freighter → Settings → Network and switch, then try again.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {/* Sign-in button */}
               <Button
-                variant="destructive"
+                id="login-sign-button"
                 className="w-full"
+                size="lg"
+                onClick={handleSign}
+                disabled={isConnecting || isWrongNetwork || !!statusMessage}
+              >
+                {statusMessage ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    {statusMessage}
+                  </>
+                ) : isWrongNetwork ? (
+                  <>
+                    <AlertTriangle className="w-4 h-4 mr-2 text-amber-500" />
+                    Switch to Testnet First
+                  </>
+                ) : (
+                  'Sign In with Freighter'
+                )}
+              </Button>
+
+              <Button
+                id="login-disconnect-button"
+                variant="ghost"
+                className="w-full text-muted-foreground"
                 onClick={handleDisconnect}
               >
                 <LogOut className="w-4 h-4 mr-2" />
-                Disconnect
+                Use a different wallet
               </Button>
             </div>
+
           ) : (
+            /* ── State: Not connected ─────────────────────────────────── */
             <div className="w-full space-y-4">
               <Button
+                id="login-connect-button"
                 className="w-full"
                 size="lg"
                 onClick={handleConnect}
@@ -251,7 +298,7 @@ export default function LoginPage() {
                 {isConnecting ? (
                   <>
                     <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    {statusMessage || 'Connecting...'}
+                    Connecting…
                   </>
                 ) : (
                   'Connect Freighter'
@@ -269,6 +316,7 @@ export default function LoginPage() {
                     <div className="flex-1 h-px bg-border/40" />
                   </div>
                   <Button
+                    id="login-mock-button"
                     variant="outline"
                     className="w-full border-dashed border-amber-500/40 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10 hover:border-amber-500/60"
                     onClick={handleMockLogin}

--- a/components/dashboard/header.tsx
+++ b/components/dashboard/header.tsx
@@ -1,21 +1,37 @@
 'use client'
 
 import Link from 'next/link'
-import { Menu, Bell, User } from 'lucide-react'
+import { Menu, Bell, LogOut, User, AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { ThemeToggle } from '@/components/ui/ThemeToggle'
+import {
+  useStellarWallet,
+  truncateStellarAddress,
+  networkLabel,
+  REQUIRED_NETWORK,
+} from '@/components/wallet-provider'
+import { useRouter } from 'next/navigation'
 
 interface DashboardHeaderProps {
   onMenuClick: () => void
 }
 
 export function DashboardHeader({ onMenuClick }: DashboardHeaderProps) {
+  const router = useRouter()
+  const { address, isConnected, isWrongNetwork, network, disconnect } = useStellarWallet()
+
+  const handleLogout = () => {
+    disconnect()
+    router.push('/login')
+  }
+
   return (
     <header className="border-b border-border/40 bg-background/80 backdrop-blur-xl sticky top-0 z-40">
       <div className="flex items-center justify-between h-16 px-6">
@@ -30,7 +46,27 @@ export function DashboardHeader({ onMenuClick }: DashboardHeaderProps) {
 
         <div className="flex-1" />
 
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-3">
+
+          {/* Wrong-network pill — compact inline warning in the header */}
+          {isConnected && isWrongNetwork && (
+            <div className="hidden sm:flex items-center gap-1.5 rounded-full bg-amber-500/15 px-3 py-1 text-xs font-medium text-amber-600 dark:text-amber-400 border border-amber-500/30">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              <span>Switch to Testnet in Freighter</span>
+            </div>
+          )}
+
+          {/* Wallet status pill (shown when connected and on correct network) */}
+          {isConnected && address && !isWrongNetwork && (
+            <div className="hidden sm:flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-600 dark:text-emerald-400 border border-emerald-500/25">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" />
+              <span className="font-mono">{truncateStellarAddress(address)}</span>
+              <span className="opacity-60">·</span>
+              <span>{networkLabel(network)}</span>
+            </div>
+          )}
+
+          {/* Notifications */}
           <Button
             variant="ghost"
             size="icon"
@@ -42,21 +78,63 @@ export function DashboardHeader({ onMenuClick }: DashboardHeaderProps) {
 
           <ThemeToggle />
 
+          {/* User menu */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="rounded-full">
+              <Button variant="ghost" size="icon" className="rounded-full relative">
                 <div className="h-8 w-8 rounded-full bg-gradient-to-br from-primary to-accent" />
+                {isConnected && isWrongNetwork && (
+                  <span className="absolute -top-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-amber-500">
+                    <AlertTriangle className="h-2.5 w-2.5 text-white" />
+                  </span>
+                )}
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="end" className="w-60">
+              {/* Wallet info section */}
+              {isConnected && address && (
+                <>
+                  <div className="px-2 py-2">
+                    <p className="text-xs text-muted-foreground mb-0.5">Connected wallet</p>
+                    <p className="text-xs font-mono text-foreground truncate">{address}</p>
+                    <div className="mt-1 flex items-center gap-1.5">
+                      <span
+                        className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full ${
+                          network === REQUIRED_NETWORK
+                            ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+                            : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+                        }`}
+                      >
+                        {networkLabel(network)}
+                      </span>
+                      {isWrongNetwork && (
+                        <span className="text-[10px] text-amber-600 dark:text-amber-400 flex items-center gap-0.5">
+                          <AlertTriangle className="h-3 w-3" /> Wrong network
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <DropdownMenuSeparator />
+                </>
+              )}
+
               <DropdownMenuItem asChild>
-                <Link href="/dashboard/profile" className="flex items-center gap-2">
+                <Link href="/dashboard/profile" className="flex items-center gap-2 cursor-pointer">
                   <User className="h-4 w-4" />
                   Profile
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuItem>Settings</DropdownMenuItem>
-              <DropdownMenuItem className="text-destructive">Logout</DropdownMenuItem>
+
+              <DropdownMenuSeparator />
+
+              <DropdownMenuItem
+                id="dashboard-logout-button"
+                onClick={handleLogout}
+                className="text-destructive focus:text-destructive flex items-center gap-2 cursor-pointer"
+              >
+                <LogOut className="h-4 w-4" />
+                Logout
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -2,21 +2,70 @@
 
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
-import { Menu, X, Wallet, User, Settings, LogOut, ChevronDown } from 'lucide-react'
+import { Menu, X, Wallet, User, Settings, LogOut, ChevronDown, AlertTriangle } from 'lucide-react'
 import { useState } from 'react'
 import { ThemeToggle } from './ui/ThemeToggle'
+import {
+  useStellarWallet,
+  truncateStellarAddress,
+  networkLabel,
+  REQUIRED_NETWORK,
+  type StellarNetwork,
+} from '@/components/wallet-provider'
+import { useRouter } from 'next/navigation'
+
+// ── Standalone sub-component ──────────────────────────────────────────────────
+
+function NetworkBadge({
+  network,
+  isConnected,
+}: {
+  network: StellarNetwork
+  isConnected: boolean
+}) {
+  if (!isConnected) return null
+  const isTestnet = network === REQUIRED_NETWORK
+  return (
+    <span
+      className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full leading-none ${
+        isTestnet
+          ? 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-400'
+          : 'bg-amber-500/20 text-amber-600 dark:text-amber-400'
+      }`}
+    >
+      {networkLabel(network)}
+    </span>
+  )
+}
 
 export function Navbar() {
+  const router = useRouter()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [profileDropdownOpen, setProfileDropdownOpen] = useState(false)
-  
-  // ⚡ Wallet Connection states (Wire these up to your Stellar/Wallet adapter hooks later)
-  const [isConnected, setIsConnected] = useState(true)
-  const walletAddress = "GBXW...4Y2T"
+
+  const {
+    address,
+    isConnected,
+    isConnecting,
+    isWrongNetwork,
+    network,
+    connect,
+    disconnect,
+  } = useStellarWallet()
 
   const closeMenus = () => {
     setMobileMenuOpen(false)
     setProfileDropdownOpen(false)
+  }
+
+  const handleConnect = async () => {
+    await connect()
+  }
+
+  const handleDisconnect = () => {
+    disconnect()
+    closeMenus()
+    router.push('/login')
   }
 
   return (
@@ -46,22 +95,41 @@ export function Navbar() {
             </Link>
           </div>
 
-          {/* Desktop Actions Area (Wallet Status + User Profiles) */}
+          {/* Desktop Actions Area */}
           <div className="hidden md:flex items-center gap-4">
-            
-            {/* Wallet Status Button Component */}
-            <Button 
-              variant={isConnected ? "outline" : "default"}
-              size="sm"
-              className="gap-2 rounded-full font-medium"
-              onClick={() => setIsConnected(!isConnected)}
-            >
-              <Wallet className="h-4 w-4" />
-              <span>{isConnected ? walletAddress : "Connect Wallet"}</span>
-              {isConnected && <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" />}
-            </Button>
 
-            {/* Profile Dropdown Component */}
+            {/* Wallet Button */}
+            {isConnected && address ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className={`gap-2 rounded-full font-medium ${isWrongNetwork ? 'border-amber-500/60 text-amber-600 dark:text-amber-400' : ''}`}
+                onClick={() => setProfileDropdownOpen(!profileDropdownOpen)}
+              >
+                {isWrongNetwork ? (
+                  <AlertTriangle className="h-4 w-4 text-amber-500" />
+                ) : (
+                  <Wallet className="h-4 w-4" />
+                )}
+                <span className="font-mono">{truncateStellarAddress(address)}</span>
+              <NetworkBadge network={network} isConnected={isConnected} />
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" />
+              </Button>
+            ) : (
+              <Button
+                id="navbar-connect-wallet"
+                variant="default"
+                size="sm"
+                className="gap-2 rounded-full font-medium"
+                onClick={handleConnect}
+                disabled={isConnecting}
+              >
+                <Wallet className="h-4 w-4" />
+                <span>{isConnecting ? 'Connecting…' : 'Connect Wallet'}</span>
+              </Button>
+            )}
+
+            {/* Profile Dropdown */}
             {isConnected && (
               <div className="relative">
                 <Button
@@ -71,16 +139,29 @@ export function Navbar() {
                   onClick={() => setProfileDropdownOpen(!profileDropdownOpen)}
                 >
                   <div className="flex h-6 w-full items-center justify-center rounded-full bg-primary/20 text-xs font-bold text-primary px-2">
-                    U
+                    {address ? address[0] : 'U'}
                   </div>
                   <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${profileDropdownOpen ? "rotate-180" : ""}`} />
                 </Button>
 
-                {/* Dropdown Menu Container */}
                 {profileDropdownOpen && (
-                  <div className="absolute right-0 mt-2 w-48 origin-top-right rounded-xl border border-border/60 bg-background p-1 shadow-xl ring-1 ring-black/5 animate-in fade-in slide-in-from-top-1 duration-150">
+                  <div className="absolute right-0 mt-2 w-56 origin-top-right rounded-xl border border-border/60 bg-background p-1 shadow-xl ring-1 ring-black/5 animate-in fade-in slide-in-from-top-1 duration-150">
+                    {/* Wallet info header */}
+                    <div className="px-3 py-2 mb-1 border-b border-border/40">
+                      <p className="text-xs text-muted-foreground">Connected wallet</p>
+                      <p className="text-xs font-mono text-foreground truncate">{address}</p>
+                      <div className="flex items-center gap-1 mt-1">
+                      <NetworkBadge network={network} isConnected={isConnected} />
+                        {isWrongNetwork && (
+                          <span className="text-[10px] text-amber-600 dark:text-amber-400">
+                            Switch to Testnet!
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
                     <Link 
-                      href="/profile" 
+                      href="/dashboard/profile" 
                       className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
                       onClick={closeMenus}
                     >
@@ -97,7 +178,8 @@ export function Navbar() {
                     </Link>
                     <hr className="my-1 border-border/40" />
                     <button 
-                      onClick={() => { setIsConnected(false); closeMenus(); }}
+                      id="navbar-disconnect-wallet"
+                      onClick={handleDisconnect}
                       className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-destructive/10 transition-colors"
                     >
                       <LogOut className="h-4 w-4" />
@@ -117,7 +199,7 @@ export function Navbar() {
             <ThemeToggle />
           </div>
 
-          {/* Mobile Hamburger Trigger Toggle Button */}
+          {/* Mobile Hamburger Trigger */}
           <button
             className="md:hidden p-2 text-muted-foreground hover:text-foreground transition-transform focus:outline-none"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
@@ -145,29 +227,49 @@ export function Navbar() {
             </Link>
             
             <div className="pt-4 border-t border-border/40 space-y-3">
-              {/* Mobile Adaptive Wallet Module */}
-              <Button 
-                variant={isConnected ? "outline" : "default"}
-                className="w-full gap-2 rounded-lg justify-center"
-                onClick={() => setIsConnected(!isConnected)}
-              >
-                <Wallet className="h-4 w-4" />
-                <span>{isConnected ? walletAddress : "Connect Wallet"}</span>
-              </Button>
-
-              {isConnected ? (
+              {isConnected && address ? (
                 <>
+                  {/* Wallet info card */}
+                  <div className="rounded-lg border border-border/40 bg-muted/30 px-3 py-2 space-y-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">Wallet</span>
+                    <NetworkBadge network={network} isConnected={isConnected} />
+                    </div>
+                    <p className="text-xs font-mono text-foreground truncate">{address}</p>
+                    {isWrongNetwork && (
+                      <p className="text-[11px] text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                        <AlertTriangle className="h-3 w-3" /> Switch to Testnet in Freighter!
+                      </p>
+                    )}
+                  </div>
+
                   <Button variant="ghost" className="w-full justify-start gap-2" asChild onClick={closeMenus}>
-                    <Link href="/profile"><User className="h-4 w-4" /> Profile</Link>
+                    <Link href="/dashboard/profile"><User className="h-4 w-4" /> Profile</Link>
                   </Button>
-                  <Button variant="ghost" className="w-full justify-start gap-2 text-destructive hover:text-destructive hover:bg-destructive/10" onClick={() => { setIsConnected(false); closeMenus(); }}>
+                  <Button
+                    id="mobile-disconnect-wallet"
+                    variant="ghost"
+                    className="w-full justify-start gap-2 text-destructive hover:text-destructive hover:bg-destructive/10"
+                    onClick={handleDisconnect}
+                  >
                     <LogOut className="h-4 w-4" /> Disconnect Wallet
                   </Button>
                 </>
               ) : (
-                <Button variant="ghost" className="w-full" asChild onClick={closeMenus}>
-                  <Link href="/login">Login</Link>
-                </Button>
+                <>
+                  <Button
+                    id="mobile-connect-wallet"
+                    className="w-full gap-2 rounded-lg justify-center"
+                    onClick={handleConnect}
+                    disabled={isConnecting}
+                  >
+                    <Wallet className="h-4 w-4" />
+                    <span>{isConnecting ? 'Connecting…' : 'Connect Wallet'}</span>
+                  </Button>
+                  <Button variant="ghost" className="w-full" asChild onClick={closeMenus}>
+                    <Link href="/login">Login</Link>
+                  </Button>
+                </>
               )}
             </div>
           </div>

--- a/components/network-banner.tsx
+++ b/components/network-banner.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { AlertTriangle, X } from "lucide-react";
+import { useState } from "react";
+import { useStellarWallet, REQUIRED_NETWORK } from "@/components/wallet-provider";
+
+const NETWORK_GUIDE: Record<string, string> = {
+  TESTNET: "Test SDF Network ; September 2015",
+  PUBLIC: "Public Global Stellar Network ; September 2015",
+};
+
+/**
+ * Sticky top banner shown when the connected wallet is on the wrong network.
+ * Instructs the user to switch networks inside their Freighter extension.
+ * Dismissible per session (re-appears on next load until the issue is fixed).
+ */
+export function NetworkBanner() {
+  const { isConnected, isWrongNetwork, network } = useStellarWallet();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!isConnected || !isWrongNetwork || dismissed) return null;
+
+  const requiredNetworkName = NETWORK_GUIDE[REQUIRED_NETWORK] ?? REQUIRED_NETWORK;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="sticky top-0 z-[60] w-full bg-amber-500/95 text-amber-950 dark:bg-amber-600/95 dark:text-amber-50 backdrop-blur-sm"
+    >
+      <div className="mx-auto flex max-w-7xl items-start justify-between gap-4 px-4 py-2.5 sm:px-6 sm:items-center">
+        <div className="flex items-start gap-3 sm:items-center">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 sm:mt-0" aria-hidden="true" />
+          <p className="text-sm font-medium leading-snug">
+            <span className="font-bold">Wrong Network Detected</span>
+            {network !== "UNKNOWN" && (
+              <span> — you&apos;re currently on <span className="font-semibold">{network === "PUBLIC" ? "Mainnet" : network}</span>.</span>
+            )}{" "}
+            TaskChain runs on{" "}
+            <span className="font-bold">Stellar Testnet</span>. Please open
+            your{" "}
+            <span className="font-bold">Freighter wallet extension</span>,
+            go to{" "}
+            <span className="italic">Settings → Network</span>, and switch
+            to &ldquo;<span className="font-bold">{requiredNetworkName}</span>&rdquo;.
+          </p>
+        </div>
+
+        <button
+          id="network-banner-dismiss"
+          aria-label="Dismiss network warning"
+          onClick={() => setDismissed(true)}
+          className="shrink-0 rounded-md p-1 opacity-80 transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-950/50"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  isConnected,
+  requestAccess,
+  getAddress,
+  getNetwork,
+} from "@stellar/freighter-api";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type StellarNetwork = "TESTNET" | "PUBLIC" | "UNKNOWN";
+
+export const REQUIRED_NETWORK: StellarNetwork = "TESTNET";
+
+interface WalletState {
+  /** Public key of the connected wallet, or null if disconnected */
+  address: string | null;
+  /** Whether Freighter is connected */
+  isConnected: boolean;
+  /** The network Freighter is currently set to */
+  network: StellarNetwork;
+  /** True when the user is connected but NOT on the required network */
+  isWrongNetwork: boolean;
+  /** True while the initial check is in-flight */
+  isInitializing: boolean;
+  /** True while a connect request is pending */
+  isConnecting: boolean;
+  /** Any Freighter or connection error */
+  error: string | null;
+}
+
+interface WalletContext extends WalletState {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  clearError: () => void;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+const StellarWalletContext = createContext<WalletContext | null>(null);
+
+const LS_ADDRESS_KEY = "stellar_wallet_address";
+const POLL_INTERVAL_MS = 3_000;
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export function StellarWalletProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [state, setState] = useState<WalletState>({
+    address: null,
+    isConnected: false,
+    network: "UNKNOWN",
+    isWrongNetwork: false,
+    isInitializing: true,
+    isConnecting: false,
+    error: null,
+  });
+
+  // Track whether the provider is still mounted to avoid state updates after unmount
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  /** Derive the unified wallet state from the raw Freighter API responses. */
+  const syncFromFreighter = useCallback(async (): Promise<void> => {
+    try {
+      const connectedRes = await isConnected();
+
+      if (!connectedRes.isConnected) {
+        if (!mountedRef.current) return;
+        setState((prev) => ({
+          ...prev,
+          address: null,
+          isConnected: false,
+          network: "UNKNOWN",
+          isWrongNetwork: false,
+          isInitializing: false,
+        }));
+        return;
+      }
+
+      const [addressRes, networkRes] = await Promise.all([
+        getAddress(),
+        getNetwork(),
+      ]);
+
+      if (!mountedRef.current) return;
+
+      const address =
+        !addressRes.error && addressRes.address ? addressRes.address : null;
+      const network = (
+        !networkRes.error && networkRes.network
+          ? networkRes.network.toUpperCase()
+          : "UNKNOWN"
+      ) as StellarNetwork;
+
+      const isWrongNetwork = !!address && network !== REQUIRED_NETWORK;
+
+      setState((prev) => ({
+        ...prev,
+        address,
+        isConnected: !!address,
+        network,
+        isWrongNetwork,
+        isInitializing: false,
+      }));
+
+      // Keep localStorage in sync
+      if (address) {
+        localStorage.setItem(LS_ADDRESS_KEY, address);
+      } else {
+        localStorage.removeItem(LS_ADDRESS_KEY);
+      }
+    } catch {
+      if (!mountedRef.current) return;
+      setState((prev) => ({ ...prev, isInitializing: false }));
+    }
+  }, []);
+
+  // ── Initial sync + polling ─────────────────────────────────────────────────
+
+  useEffect(() => {
+    // Small delay to let the Freighter extension inject into the page
+    const initTimer = setTimeout(syncFromFreighter, 500);
+    const pollTimer = setInterval(syncFromFreighter, POLL_INTERVAL_MS);
+
+    return () => {
+      clearTimeout(initTimer);
+      clearInterval(pollTimer);
+    };
+  }, [syncFromFreighter]);
+
+  // ── Connect ───────────────────────────────────────────────────────────────
+
+  const connect = useCallback(async () => {
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+    try {
+      const accessRes = await requestAccess();
+      if (accessRes.error) {
+        throw new Error(
+          accessRes.error.message || "Connection request was rejected."
+        );
+      }
+
+      // After requesting access, do a full sync to pick up address + network
+      await syncFromFreighter();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to connect wallet.";
+      if (mountedRef.current) {
+        setState((prev) => ({ ...prev, error: message }));
+      }
+    } finally {
+      if (mountedRef.current) {
+        setState((prev) => ({ ...prev, isConnecting: false }));
+      }
+    }
+  }, [syncFromFreighter]);
+
+  // ── Disconnect ────────────────────────────────────────────────────────────
+
+  const disconnect = useCallback(() => {
+    localStorage.removeItem(LS_ADDRESS_KEY);
+    localStorage.removeItem("tc_dev_access_token");
+    setState((prev) => ({
+      ...prev,
+      address: null,
+      isConnected: false,
+      network: "UNKNOWN",
+      isWrongNetwork: false,
+      error: null,
+    }));
+  }, []);
+
+  const clearError = useCallback(() => {
+    setState((prev) => ({ ...prev, error: null }));
+  }, []);
+
+  const value: WalletContext = {
+    ...state,
+    connect,
+    disconnect,
+    clearError,
+  };
+
+  return (
+    <StellarWalletContext.Provider value={value}>
+      {children}
+    </StellarWalletContext.Provider>
+  );
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/** Access the global Stellar wallet state and actions from any client component. */
+export function useStellarWallet(): WalletContext {
+  const ctx = useContext(StellarWalletContext);
+  if (!ctx) {
+    throw new Error(
+      "useStellarWallet must be used within a <StellarWalletProvider>."
+    );
+  }
+  return ctx;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Shorten a Stellar public key for display: `GABCD...XY2T` */
+export function truncateStellarAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 5)}...${address.slice(-4)}`;
+}
+
+/** Human-friendly label for a network type */
+export function networkLabel(network: StellarNetwork): string {
+  const labels: Record<StellarNetwork, string> = {
+    TESTNET: "Testnet",
+    PUBLIC: "Mainnet",
+    UNKNOWN: "Unknown",
+  };
+  return labels[network];
+}

--- a/components/wallet-status.tsx
+++ b/components/wallet-status.tsx
@@ -57,7 +57,7 @@ export function WalletStatus() {
 
   useEffect(() => {
     const interval = setInterval(checkWalletStatus, 3000);
-    
+
     return () => clearInterval(interval);
   }, [checkWalletStatus]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4681,7 +4680,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4692,7 +4690,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4752,7 +4749,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -5299,7 +5295,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5744,7 +5739,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6344,8 +6338,7 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.1.tgz",
       "integrity": "sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.5.1",
@@ -6634,7 +6627,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6820,7 +6812,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8753,7 +8744,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.10.tgz",
       "integrity": "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.0.10",
         "@swc/helpers": "0.5.15",
@@ -9172,7 +9162,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10694,7 +10683,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10726,7 +10714,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10739,7 +10726,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
       "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11586,8 +11572,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11659,7 +11644,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11871,7 +11855,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12267,7 +12250,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION

Implemented full Stellar Testnet + Freighter wallet integration across the frontend with proper network detection, a global state context, and gated authentication.

Changes Made
[NEW] components/wallet-provider.tsx
A global React context (StellarWalletProvider) that:

Polls Freighter every 3 seconds for connection status, wallet address and active network.
Exposes useStellarWallet() hook with: address, isConnected, network, isWrongNetwork, connect(), disconnect().
Syncs the wallet address with localStorage.
Defines REQUIRED_NETWORK = "TESTNET" as the single source of truth.
[NEW] components/network-banner.tsx
A sticky top banner that appears only when the wallet is connected but on the wrong network. It:

Is dismissible per-session.
Instructs the user to switch networks inside Freighter → Settings → Network.
[MODIFY] app/layout.tsx
Wrapped the entire app in <StellarWalletProvider>.
Mounted <NetworkBanner /> globally so it shows on every page.
[MODIFY] components/navbar.tsx
Replaced all mock wallet state with real data from useStellarWallet():

Shows real truncated wallet address when connected.
Shows a colored Testnet/Mainnet network badge.
Shows an amber AlertTriangle icon when on the wrong network.
Profile dropdown shows the full address and network info.
Real connect() / disconnect() actions hooked up.
Mobile menu updated to match.
[MODIFY] components/dashboard/header.tsx
Displays a compact green "connected" pill showing the wallet address + network when on Testnet.
Displays an amber inline warning strip when on the wrong network.
User dropdown shows wallet address, network badge, and wrong-network indicator.
Logout button calls disconnect() and redirects to /login.
[MODIFY] app/login/page.tsx
Refactored to a clean two-step auth flow:

Step 1 — Connect: Calls connect() from the provider (uses requestAccess).
Step 2 — Sign & Authenticate: After connecting, the page shows the wallet card. If on the wrong network, a prominent amber warning block appears and the Sign In button is disabled with a "Switch to Testnet First" label. Only when on Testnet does the Freighter signature → backend verify flow proceed.

Closes #80 